### PR TITLE
feat: add consumer authorization hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "x402 + API key payment gateway for Tangle agent products. Mount on any Hono app to expose agents as paid OpenAI-compatible endpoints.",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "x402 + API key payment gateway for Tangle agent products. Mount on any Hono app to expose agents as paid OpenAI-compatible endpoints.",
   "exports": {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,6 +23,14 @@ import { generateRequestId, type GatewayObserver, type RequestContext } from './
  *   POST /:slug/chat/completions  — OpenAI-compatible chat endpoint (paid)
  */
 export function createAgentGateway(config: GatewayConfig) {
+  // Production gateways must verify x402 signatures. Tests and local
+  // dev can opt into the explicit demo path.
+  if (!config.x402.verifySigner && !config.x402.demoMode) {
+    throw new Error(
+      'createAgentGateway: x402.verifySigner is required in production. ' +
+        'For tests, set x402.demoMode: true explicitly.',
+    )
+  }
   const gw = new Hono()
   const maxLen = config.maxMessageLength ?? 8000
   const rateLimitStore: RateLimitStore = config.rateLimitStore ?? new MemoryRateLimitStore()
@@ -240,6 +248,29 @@ export function createAgentGateway(config: GatewayConfig) {
 
     if (!userMessage) {
       return c.json({ error: { message: 'No user message provided', type: 'invalid_request' } }, 400)
+    }
+
+    // 5b. Optional host authorization. Runs after payment/rate-limit
+    // checks and before sandbox allocation.
+    if (config.authorizeConsumer) {
+      const authz = await config.authorizeConsumer(agent, {
+        method: paymentMethod,
+        consumerId: consumerId!,
+        keyId: keyInfo?.keyId,
+        requestId,
+      })
+      if (!authz.allow) {
+        return c.json(
+          {
+            error: {
+              message: authz.reason,
+              type: 'authorization_denied',
+              code: authz.code,
+            },
+          },
+          { status: 403, headers: { 'X-Request-Id': requestId } },
+        )
+      }
     }
 
     // 6. Get sandbox and stream response with output filtering

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,16 @@ export interface GatewayConfig {
   /** Get a sandbox instance for the agent. Called after payment is verified. */
   getSandbox: (agent: AgentMeta) => Promise<SandboxBox>
 
+  /**
+   * Optional host authorization hook fired after payment verification
+   * and before sandbox resolution. Use it for per-agent allowlists,
+   * per-consumer quotas, contract scope checks, and instance ownership.
+   */
+  authorizeConsumer?: (
+    agent: AgentMeta,
+    consumer: { method: PaymentMethod; consumerId: string; keyId?: string; requestId: string },
+  ) => Promise<{ allow: true } | { allow: false; reason: string; code: string }>
+
   /** Record a usage event after request completes. */
   recordUsage: (event: GatewayUsageEvent) => Promise<void>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,40 @@ export interface AgentMeta {
   remoteBearerToken: string | null
   /** Whether agent is published and accepting requests */
   enabled: boolean
+  /**
+   * CLI harness backend that runs this agent inside the sandbox sidecar.
+   *
+   * When set, the host's `getSandbox()` SHOULD return a `SandboxBox`
+   * whose `streamPrompt` POSTs to the sidecar's
+   * `POST /agent/invoke/chat/completions` endpoint with
+   * `model: "<harness>/<harnessModel>"` — that endpoint runs the
+   * harness against the sandbox workspace and streams OpenAI-shape
+   * `chat.completion.chunk` frames back.
+   *
+   * When unset (legacy / template mode), the host's `streamPrompt`
+   * falls back to the template's own `/api/chat/completions` (proxied
+   * via the sidecar's `/agent/invoke`).
+   *
+   * Known harnesses (registered in agent-dev-container's
+   * cli-agent-bindings.ts): opencode, claude-code, codex, kimi-code,
+   * amp, factory-droids, pi, hermes, openclaw, forge, acp, cursor.
+   * Aliases the sidecar canonicalizes: claude → claude-code,
+   * kimi → kimi-code, factory → factory-droids.
+   */
+  harness?: string
+  /**
+   * Model identifier to pass after the harness in the
+   * `<harness>/<model>` slash form. Format is harness-specific:
+   *   claude-code:   "sonnet", "opus", or a versioned id like
+   *                  "claude-sonnet-4-20250514"
+   *   opencode:      "anthropic/claude-sonnet-4-5", "openai/gpt-4o", …
+   *                  (opencode embeds provider before model)
+   *   codex:         "gpt-5-codex"
+   *   kimi-code:     "kimi-for-coding"
+   *
+   * Only meaningful when `harness` is set; ignored otherwise.
+   */
+  harnessModel?: string
 }
 
 // --- Payment ---

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -5,8 +5,12 @@ import type { NonceStore } from './nonce-store'
  * Verify x402 SpendAuth signature (EIP-712).
  * Returns the signer address (commitment) if valid, null otherwise.
  *
- * DEMO MODE (demoMode: true): accepts any well-formed header structure.
- * PRODUCTION: requires config.verifySigner callback for on-chain verification.
+ *   demoMode: true               — accepts any well-formed header
+ *                                  shape after replay/expiry checks.
+ *                                  Tests + local dev only.
+ *   verifySigner present         — production verification path.
+ *   neither                      — rejected by createAgentGateway and
+ *                                  by this function as defense-in-depth.
  */
 export async function verifyX402(
   spendAuthHeader: string,
@@ -37,12 +41,11 @@ export async function verifyX402(
       await nonceStore.markSeen(nonceKey, Math.max(ttl, 60))
     }
 
-    // Production: delegate to on-chain verification
     if (config.verifySigner) {
       const verified = await config.verifySigner(raw)
       if (!verified) return null
     } else if (!config.demoMode) {
-      console.warn('[agent-gateway] x402 verification running without verifySigner — set demoMode: true to suppress this warning')
+      return null
     }
 
     return raw.commitment

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -467,6 +467,88 @@ describe('POST /:slug/chat/completions — injection blocking', () => {
   })
 })
 
+describe('POST /:slug/chat/completions — authorizeConsumer hook', () => {
+  it('blocks consumers an authorizeConsumer hook denies — regression: hosts must be able to allowlist', async () => {
+    const calls: Array<{ agentId: string; consumerId: string; requestId: string }> = []
+    const { app } = buildHarness({
+      authorizeConsumer: async (agent, consumer) => {
+        calls.push({ agentId: agent.id, consumerId: consumer.consumerId, requestId: consumer.requestId })
+        return { allow: false, reason: 'consumer not on allowlist for this instance', code: 'consumer_not_allowed' }
+      },
+    })
+    const res = await app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': buildSpendAuth({ nonce: '5001' }) },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+    })
+    expect(res.status).toBe(403)
+    const body = await res.json() as { error: { message: string; code: string; type: string } }
+    expect(body.error.code).toBe('consumer_not_allowed')
+    expect(body.error.type).toBe('authorization_denied')
+    expect(calls).toHaveLength(1)
+    expect(calls[0].consumerId).toBeTruthy()
+    expect(calls[0].requestId).toMatch(/.+/)
+  })
+
+  it('allows the call to proceed when authorizeConsumer returns allow: true', async () => {
+    const { app, usage } = buildHarness({
+      authorizeConsumer: async () => ({ allow: true }),
+    })
+    const res = await app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': buildSpendAuth({ nonce: '5002' }) },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+    })
+    expect(res.status).toBe(200)
+    await readSse(res)
+    expect(usage).toHaveLength(1)
+  })
+
+  it('does not call getSandbox when authorizeConsumer denies — regression: never pay sandbox cost for a forbidden caller', async () => {
+    let getSandboxCalls = 0
+    const sandbox = new StubSandbox(['ok'])
+    const { app } = buildHarness({
+      getSandbox: async () => { getSandboxCalls++; return sandbox },
+      authorizeConsumer: async () => ({ allow: false, reason: 'no', code: 'denied' }),
+    })
+    await app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': buildSpendAuth({ nonce: '5003' }) },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+    })
+    expect(getSandboxCalls).toBe(0)
+  })
+})
+
+describe('createAgentGateway — production-config guard', () => {
+  it('refuses to boot when neither verifySigner nor demoMode is set', () => {
+    expect(() => createAgentGateway({
+      resolveAgent: async () => null,
+      getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
+      recordUsage: async () => { /* unused */ },
+      x402: { operatorAddress, chainId: 3799 }, // no verifySigner, no demoMode
+    })).toThrow(/verifySigner is required in production/)
+  })
+
+  it('boots when demoMode: true is set explicitly (test path)', () => {
+    expect(() => createAgentGateway({
+      resolveAgent: async () => null,
+      getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
+      recordUsage: async () => { /* unused */ },
+      x402: { operatorAddress, chainId: 3799, demoMode: true },
+    })).not.toThrow()
+  })
+
+  it('boots when verifySigner is supplied (production path)', () => {
+    expect(() => createAgentGateway({
+      resolveAgent: async () => null,
+      getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
+      recordUsage: async () => { /* unused */ },
+      x402: { operatorAddress, chainId: 3799, verifySigner: async () => true },
+    })).not.toThrow()
+  })
+})
+
 describe('POST /:slug/chat/completions — error safety', () => {
   it('sanitizes errors from sandbox — regression: stack traces must not leak internal paths', async () => {
     const throwingBox: SandboxBox = {


### PR DESCRIPTION
## Summary\n- add optional `authorizeConsumer` hook after payment/rate-limit and before sandbox allocation\n- fail closed when x402 production verification is not configured unless explicit demo mode is enabled\n- add regression tests for denied/allowed consumers, sandbox allocation avoidance, and production boot guard\n- bump package version to 0.5.0, already published to npm\n\n## Verification\n- pnpm test\n- pnpm typecheck\n- pnpm build\n- npm pack --dry-run\n- npm view confirms latest=0.5.0