### PR TITLE
ci: add tag-triggered npm publish workflow with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,80 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify tag/version lock
+        run: |
+          NPM_VERSION=$(node -p "require('./package.json').version")
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+            if [ "$TAG_VERSION" != "$NPM_VERSION" ]; then
+              echo "::error::Tag/version mismatch: tag=$TAG_VERSION package=$NPM_VERSION."
+              exit 1
+            fi
+          fi
+          echo "Version locked: $NPM_VERSION"
+
+  publish-npm:
+    needs: verify
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+
+      # Idempotent: re-running a tag whose npm version is already published
+      # must not fail the workflow.
+      - name: Publish to npm (skip if already published)
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "$NAME@$VERSION already on registry; skipping publish"
+          else
+            pnpm publish --no-git-checks --access public --provenance
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Problem

`@tangle-network/agent-gateway` has **no CI publish workflow** — it's published manually, so releases carry no provenance and depend on a local environment. (Local is at 0.7.0; npm latest is 0.6.0.)

## Change

Add `.github/workflows/publish.yml`, modeled on the sibling repos (`agent-runtime`, `agent-knowledge`): tag-push (`v*`) triggered, runs typecheck + test + build, verifies the tag matches `package.json`, and publishes with `--provenance` (the repo is public + `id-token: write`). Idempotent (skips if the version is already on npm).

## To make it functional

- This repo needs an **`NPM_TOKEN`** secret with publish rights to `@tangle-network/agent-gateway` (the sibling repos use the same secret name). *Being set alongside this PR.*
- Releases become **tag-triggered**: `git tag v0.7.0 && git push --tags` publishes 0.7.0.
- Optional: register a Trusted Publisher on npm to go fully tokenless later.