### PR TITLE
fix(auth): fail closed for unconfigured payment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # @tangle-network/agent-gateway
 
-Hono middleware that turns any Tangle agent app into a paid API. Wrap your chat endpoint to accept API keys, x402 SpendAuth, or MPP credentials — with scope enforcement, per-key rate limits, nonce replay protection, prompt-injection detection, and publish routes for the marketplace.
+Hono middleware that turns any Tangle agent app into a paid API.
+It exposes one shared request pipeline for API keys, x402 SpendAuth, and MPP credentials, with scope enforcement, per-key rate limits, nonce replay protection, prompt-injection detection, and publish routes for the marketplace.
 
 ## Install
 
@@ -11,16 +12,36 @@ npm install @tangle-network/agent-gateway
 ## Usage
 
 ```ts
-import { createAgentGateway } from '@tangle-network/agent-gateway'
+import {
+  createAgentGateway,
+  verifyApiKeyFromStore,
+} from '@tangle-network/agent-gateway'
 import { Hono } from 'hono'
 
 const app = new Hono()
-app.use('/chat/*', createAgentGateway({
-  apiKeyStore: myKeyStore,
-  x402: { verifierUrl: 'https://router.tangle.tools/x402/verify' },
-  rateLimits: { perKey: { rpm: 60 } },
+app.route('/v1/agents', createAgentGateway({
+  resolveAgent: loadPublishedAgent,
+  getSandbox: openAgentSandbox,
+  recordUsage: recordUsageEvent,
+  x402: {
+    operatorAddress: '0x…',
+    chainId: 3799,
+    verifySigner: verifySpendAuthSignature,
+  },
+  verifyApiKey: (authHeader) => verifyApiKeyFromStore(authHeader, apiKeyStore),
 }))
 ```
+
+`x402.verifySigner` is required for production.
+Set `x402.demoMode: true` only for local development and tests; that explicit mode also enables the built-in `sk_agent_*` demo key verifier.
+
+MPP is method-specific.
+Configure `mpp.verifySigner` for production MPP credentials; it receives the decoded JSON payload when available plus the original decoded credential, and returns the authenticated consumer ID or `null`.
+The default `blueprintevm` method may reuse `x402.verifySigner` when its credential has the compatible x402 payload shape.
+Other methods are not accepted until they have their own verifier.
+
+The same authentication, authorization, rate-limit, filtering, sandbox, settlement, and usage-recording pipeline is used by the OpenAI-compatible and A2A endpoints.
+Wire protocol handlers only translate their request and response shapes.
 
 ## A2A protocol
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "packageManager": "pnpm@10.28.0",
   "repository": {
     "type": "git",

--- a/src/a2a/agent-card.ts
+++ b/src/a2a/agent-card.ts
@@ -4,12 +4,13 @@
  * fetch the card from `<url>/.well-known/agent.json` per A2A convention.
  *
  * Auth schemes advertised reflect the gateway's actually-accepted payment
- * methods (x402 always; mpp when configured; Bearer for API keys). Skills
+ * methods (x402 always; mpp and Bearer only when configured). Skills
  * fall back to a single synthesized "chat" skill when the AgentMeta doesn't
  * declare its own — most consumers will override.
  */
 
 import type { AgentMeta, GatewayConfig } from '../types'
+import { isApiKeyAuthEnabled, isMppAuthEnabled } from '../verify'
 import type { AgentCard, AgentSkill } from './types'
 
 export function buildAgentCard(
@@ -18,8 +19,8 @@ export function buildAgentCard(
   agentUrl: string,
 ): AgentCard {
   const schemes: string[] = ['x402']
-  if (config.mpp) schemes.push('mpp')
-  schemes.push('Bearer')
+  if (isMppAuthEnabled(config)) schemes.push('mpp')
+  if (isApiKeyAuthEnabled(config)) schemes.push('Bearer')
 
   const skills: AgentSkill[] =
     agent.skills && agent.skills.length > 0

--- a/src/a2a/handler.ts
+++ b/src/a2a/handler.ts
@@ -95,7 +95,7 @@ export function createA2AHandlers(deps: A2AHandlerDeps) {
     const slug = c.req.param('slug')
     if (!slug) return c.json({ error: 'slug required' }, 400)
     const agent = await deps.config.resolveAgent(slug)
-    if (!agent) {
+    if (!agent || !agent.enabled) {
       return c.json({ error: 'Agent not found or not published' }, 404)
     }
     const url = new URL(c.req.url)
@@ -795,4 +795,3 @@ async function maybeDeliverPush(task: Task, deps: A2AHandlerDeps): Promise<void>
     )
   }
 }
-

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -21,7 +21,13 @@ import type {
   GatewayConfig,
   PaymentMethod,
 } from './types'
-import { defaultVerifyApiKey, verifyMpp, verifyX402 } from './verify'
+import {
+  defaultVerifyApiKey,
+  isApiKeyAuthEnabled,
+  isMppAuthEnabled,
+  verifyMpp,
+  verifyX402,
+} from './verify'
 
 /** Single bundle of long-lived gateway state shared across all handlers in one createAgentGateway call. */
 export interface GatewayState {
@@ -68,7 +74,7 @@ export async function authenticateAndGuard(
   await state.obs?.onRequestStart?.(ctx)
 
   const agent = await config.resolveAgent(slug)
-  if (!agent) {
+  if (!agent || !agent.enabled) {
     return c.json({ error: { message: 'Agent not found', type: 'not_found' } }, 404)
   }
   if (!messages?.length) {
@@ -109,11 +115,11 @@ export async function authenticateAndGuard(
     }
     consumerId = signer
     paymentMethod = 'x402'
-  } else if (config.mpp && authHeader.toLowerCase().startsWith('payment ')) {
-    const signer = await verifyMpp(authHeader, config.mpp, config.x402)
+  } else if (isMppAuthEnabled(config) && authHeader.toLowerCase().startsWith('payment ')) {
+    const signer = await verifyMpp(authHeader, config.mpp!, config.x402, state.nonceStore)
     if (!signer) {
-      const realm = config.mpp.realm
-      const method = config.mpp.method ?? 'blueprintevm'
+      const realm = config.mpp!.realm
+      const method = config.mpp!.method ?? 'blueprintevm'
       await state.obs?.onAuthFailure?.(ctx, {
         method: 'mpp',
         code: 'invalid_mpp_credential',
@@ -139,7 +145,18 @@ export async function authenticateAndGuard(
     consumerId = signer
     paymentMethod = 'mpp'
   } else if (authHeader.startsWith('Bearer ')) {
-    const verify = config.verifyApiKey ?? defaultVerifyApiKey
+    const verify = config.verifyApiKey ?? (config.x402.demoMode ? defaultVerifyApiKey : null)
+    if (!verify || !isApiKeyAuthEnabled(config)) {
+      await state.obs?.onAuthFailure?.(ctx, {
+        method: 'apikey',
+        code: 'api_keys_not_configured',
+        httpStatus: 401,
+      })
+      return c.json(
+        { error: { message: 'API key authentication is not configured', type: 'authentication_error' } },
+        { status: 401, headers: { 'X-Request-Id': requestId } },
+      )
+    }
     const key = await verify(authHeader)
     if (!key) {
       await state.obs?.onAuthFailure?.(ctx, {
@@ -179,13 +196,13 @@ export async function authenticateAndGuard(
       httpStatus: 402,
     })
     const methods: string[] = ['x402']
-    if (config.mpp) methods.push('mpp')
-    methods.push('api_key')
+    if (isMppAuthEnabled(config)) methods.push('mpp')
+    if (isApiKeyAuthEnabled(config)) methods.push('api_key')
     const headers: Record<string, string> = {
       'X-Payment-Required': methods.join(', '),
       'X-Request-Id': requestId,
     }
-    if (config.mpp) {
+    if (isMppAuthEnabled(config) && config.mpp) {
       headers['WWW-Authenticate'] =
         `Payment realm="${config.mpp.realm}", method="${config.mpp.method ?? 'blueprintevm'}"`
     }
@@ -201,14 +218,18 @@ export async function authenticateAndGuard(
             credits_address: config.x402.creditsAddress,
             estimated_amount_per_request: '20000',
           },
-          ...(config.mpp
+          ...(isMppAuthEnabled(config) && config.mpp
             ? { mpp: { realm: config.mpp.realm, method: config.mpp.method ?? 'blueprintevm' } }
             : {}),
-          api_key: {
-            purchase_url: config.baseUrl
-              ? `${config.baseUrl}/agents/${slug}/api-keys`
-              : undefined,
-          },
+          ...(isApiKeyAuthEnabled(config)
+            ? {
+                api_key: {
+                  purchase_url: config.baseUrl
+                    ? `${config.baseUrl}/agents/${slug}/api-keys`
+                    : undefined,
+                },
+              }
+            : {}),
         },
       },
       { status: 402, headers },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 export { createAgentGateway } from './middleware'
-export { verifyX402, verifyMpp, defaultVerifyApiKey } from './verify'
+export {
+  verifyX402,
+  verifyMpp,
+  defaultVerifyApiKey,
+  isApiKeyAuthEnabled,
+  isMppAuthEnabled,
+} from './verify'
 export {
   filterConsumerMessages,
   filterConsumerMessagesStrict,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,6 +14,7 @@ import { MemoryNonceStore } from './nonce-store'
 import { type GatewayObserver, type RequestContext, generateRequestId } from './observer'
 import { MemoryRateLimitStore, type RateLimitStore } from './rate-limit'
 import type { ChatCompletionChunk, ChatCompletionRequest, GatewayConfig } from './types'
+import { isApiKeyAuthEnabled, isMppAuthEnabled } from './verify'
 
 /**
  * Create a Hono router that serves the agent gateway.
@@ -51,7 +52,7 @@ export function createAgentGateway(config: GatewayConfig) {
   gw.get('/:slug/chat/completions', async (c) => {
     const slug = c.req.param('slug')
     const agent = await config.resolveAgent(slug)
-    if (!agent) return c.json({ error: 'Agent not found or not published' }, 404)
+    if (!agent || !agent.enabled) return c.json({ error: 'Agent not found or not published' }, 404)
 
     const paymentMethods: Array<Record<string, unknown>> = [
       {
@@ -61,14 +62,14 @@ export function createAgentGateway(config: GatewayConfig) {
         credits_contract: config.x402.creditsAddress,
       },
     ]
-    if (config.mpp) {
+    if (isMppAuthEnabled(config)) {
       paymentMethods.push({
         type: 'mpp',
-        realm: config.mpp.realm,
-        method: config.mpp.method ?? 'blueprintevm',
+        realm: config.mpp!.realm,
+        method: config.mpp!.method ?? 'blueprintevm',
       })
     }
-    paymentMethods.push({ type: 'api_key', prefix: 'sk_agent_' })
+    if (isApiKeyAuthEnabled(config)) paymentMethods.push({ type: 'api_key', prefix: 'sk_agent_' })
 
     return c.json({
       slug: agent.slug,
@@ -231,4 +232,3 @@ function streamChatCompletions(
     },
   })
 }
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,18 @@ export interface MppConfig {
   realm: string
   /** MPP method name (default: "blueprintevm") */
   method?: string
+  /**
+   * Production verifier for the method-specific credential. Return the
+   * authenticated consumer id, or null when the credential is invalid.
+   * The callback receives the decoded JSON payload when one exists plus the
+   * original decoded credential so non-JSON methods can verify their own form.
+   * Omit only when x402.demoMode is explicitly enabled for local testing, or
+   * when x402.verifySigner handles an x402-compatible MPP credential.
+   */
+  verifySigner?: (
+    payload: Record<string, unknown>,
+    context: { method: string; credential: string },
+  ) => Promise<string | null>
 }
 
 export interface PaymentResult {
@@ -194,12 +206,13 @@ export interface GatewayConfig {
   /** x402 payment configuration */
   x402: X402Config
 
-  /** MPP (Machine Payments Protocol) configuration. If provided, gateway accepts Authorization: Payment headers. */
+  /** MPP (Machine Payments Protocol) configuration. It is advertised only when a production verifier or explicit demo mode is available. */
   mpp?: MppConfig
 
   /**
    * Verify an API key. Return key info if valid, null if invalid.
-   * Default: accepts any `sk_agent_*` key (demo mode).
+   * In explicit x402 demo mode, the built-in verifier accepts `sk_agent_*` keys.
+   * Production gateways must provide this callback.
    */
   verifyApiKey?: (authHeader: string) => Promise<ApiKeyInfo | null>
 

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,5 +1,25 @@
-import type { X402Config, MppConfig, ApiKeyInfo } from './types'
+import type { X402Config, MppConfig, ApiKeyInfo, GatewayConfig } from './types'
 import type { NonceStore } from './nonce-store'
+
+/** Pure capability checks shared by discovery and every request protocol. */
+export function isApiKeyAuthEnabled(
+  config: Pick<GatewayConfig, 'verifyApiKey' | 'x402'>,
+): boolean {
+  return config.verifyApiKey !== undefined || config.x402.demoMode === true
+}
+
+/** MPP is enabled only when a real verifier or explicit demo mode exists. */
+export function isMppAuthEnabled(
+  config: Pick<GatewayConfig, 'mpp' | 'x402'>,
+): boolean {
+  const method = config.mpp?.method ?? 'blueprintevm'
+  return Boolean(
+    config.mpp &&
+      (config.mpp.verifySigner !== undefined ||
+        (method === 'blueprintevm' && config.x402.verifySigner !== undefined) ||
+        config.x402.demoMode === true),
+  )
+}
 
 /**
  * Verify x402 SpendAuth signature (EIP-712).
@@ -32,20 +52,22 @@ export async function verifyX402(
     // Reject zero-amount payments
     if (amount <= 0n) return null
 
-    // Reject replayed nonces
     const nonceKey = `${raw.commitment}:${nonce.toString()}`
-    if (nonceStore) {
-      if (await nonceStore.hasSeen(nonceKey)) return null
-      // Mark seen with TTL matching the expiry window (max 1 hour)
-      const ttl = Math.min(Number(expiry) - Math.floor(Date.now() / 1000), 3600)
-      await nonceStore.markSeen(nonceKey, Math.max(ttl, 60))
-    }
+    if (nonceStore && await nonceStore.hasSeen(nonceKey)) return null
 
     if (config.verifySigner) {
       const verified = await config.verifySigner(raw)
       if (!verified) return null
     } else if (!config.demoMode) {
       return null
+    }
+
+    // Check and mark only after the signature is accepted. Otherwise an
+    // invalid request can burn a valid payer nonce and deny the real request.
+    if (nonceStore) {
+      // Mark seen with TTL matching the expiry window (max 1 hour)
+      const ttl = Math.min(Number(expiry) - Math.floor(Date.now() / 1000), 3600)
+      await nonceStore.markSeen(nonceKey, Math.max(ttl, 60))
     }
 
     return raw.commitment
@@ -57,43 +79,88 @@ export async function verifyX402(
 /**
  * Verify MPP (Machine Payments Protocol) Authorization: Payment header.
  *
- * MPP uses `Authorization: Payment <method> <credential>` format where
- * the credential is a base64url-encoded JSON wrapping the same EIP-3009
- * payment payload that x402 uses. This means existing x402 wallets work
- * unchanged over the MPP wire format.
+ * MPP uses `Authorization: Payment <method> <credential>` format. The
+ * credential is method-specific; `MppConfig.verifySigner` owns verification
+ * and returns the consumer identity. The built-in `blueprintevm` path can
+ * reuse the x402 verifier for credentials with the compatible payload shape.
  *
  * Returns the signer address if valid, null otherwise.
- * In demo mode, accepts any well-formed Payment header.
+ * In demo mode, accepts any well-formed Payment header with an identity.
  */
 export async function verifyMpp(
   authHeader: string,
-  _config: MppConfig,
+  config: MppConfig,
   x402Config: X402Config,
+  nonceStore?: NonceStore,
 ): Promise<string | null> {
   // MPP format: "Payment <method> <base64url-credential>"
   const match = authHeader.match(/^Payment\s+(\S+)\s+(\S+)$/i)
   if (!match) return null
 
-  const [, , credentialB64] = match
+  const [, method, credentialB64] = match
+  if (config.method && method !== config.method) return null
 
   try {
-    // Decode base64url credential → JSON with the same EIP-3009 payload
+    if (!/^[A-Za-z0-9_-]+$/.test(credentialB64)) return null
     const decoded = Buffer.from(credentialB64, 'base64url').toString('utf-8')
-    const credential = JSON.parse(decoded)
+    let payload: Record<string, unknown> = {}
+    try {
+      const credential = JSON.parse(decoded) as unknown
+      if (credential && typeof credential === 'object' && !Array.isArray(credential)) {
+        const nested = (credential as Record<string, unknown>).payload
+        payload =
+          nested && typeof nested === 'object' && !Array.isArray(nested)
+            ? (nested as Record<string, unknown>)
+            : (credential as Record<string, unknown>)
+      }
+    } catch {
+      // Method-specific verifiers may accept a non-JSON credential format.
+    }
 
-    // The credential payload wraps the same fields x402 uses
-    const payload = credential.payload ?? credential
-    if (!payload.commitment && !payload.from) return null
+    const nonceKey =
+      nonceStore && payload.nonce !== undefined
+        ? `mpp:${method}:${String(payload.commitment ?? payload.from ?? 'unknown')}:${String(payload.nonce)}`
+        : null
+    if (nonceKey && await nonceStore!.hasSeen(nonceKey)) return null
 
-    // Validate operator match (same as x402)
+    let consumerId: string | null = null
+    if (config.verifySigner) {
+      consumerId = await config.verifySigner(payload, { method, credential: decoded })
+    } else if (method === 'blueprintevm' && x402Config.verifySigner && payload.commitment) {
+      const verified = await x402Config.verifySigner(payload)
+      consumerId = verified ? String(payload.commitment) : null
+    } else if (x402Config.demoMode) {
+      const identity = payload.commitment ?? payload.from
+      if (typeof identity !== 'string' || identity.length === 0) return null
+      consumerId = identity
+    } else {
+      return null
+    }
+    if (!consumerId) return null
+
+    // Validate common EVM fields when present. Method-specific verifiers own
+    // the complete credential contract for non-EVM methods.
     const operator = payload.operator ?? payload.to
-    if (operator && operator.toLowerCase() !== x402Config.operatorAddress.toLowerCase()) return null
+    if (operator !== undefined) {
+      if (typeof operator !== 'string' || operator.toLowerCase() !== x402Config.operatorAddress.toLowerCase()) {
+        return null
+      }
+    }
+    if (payload.amount !== undefined && BigInt(String(payload.amount)) <= 0n) return null
+    if (payload.nonce !== undefined) BigInt(String(payload.nonce))
+    if (payload.expiry !== undefined && BigInt(String(payload.expiry)) < BigInt(Math.floor(Date.now() / 1000))) {
+      return null
+    }
 
-    // Validate bigint fields if present
-    if (payload.amount) BigInt(payload.amount)
-    if (payload.nonce) BigInt(payload.nonce)
+    if (nonceStore && payload.nonce !== undefined) {
+      const expiry = payload.expiry === undefined
+        ? Math.floor(Date.now() / 1000) + 3600
+        : Number(payload.expiry)
+      const ttl = Math.min(expiry - Math.floor(Date.now() / 1000), 3600)
+      await nonceStore.markSeen(nonceKey!, Math.max(ttl, 60))
+    }
 
-    return payload.commitment ?? payload.from ?? null
+    return consumerId
   } catch {
     return null
   }

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -183,6 +183,57 @@ describe('GET /:slug/chat/completions (discovery)', () => {
     expect(body.hosting.mode).toBe('sovereign')
     expect(body.hosting.endpoint).toBe('https://remote.op/sandbox/42')
   })
+
+  it('does not advertise or accept demo API keys on a production-configured gateway', async () => {
+    const { app } = buildHarness({
+      x402: {
+        operatorAddress,
+        chainId: 3799,
+        demoMode: false,
+        verifySigner: async () => true,
+      },
+    })
+    const discovery = await app.request('/v1/agents/test-agent/chat/completions')
+    const discoveryBody = await discovery.json() as { payment_methods: Array<{ type: string }> }
+    expect(discoveryBody.payment_methods.map((method) => method.type)).not.toContain('api_key')
+
+    const response = await app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer sk_agent_fake' },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('does not advertise an MPP method without a compatible verifier', async () => {
+    const { app } = buildHarness({
+      mpp: { realm: 'agents.tangle.tools', method: 'stripe' },
+      x402: {
+        operatorAddress,
+        chainId: 3799,
+        demoMode: false,
+        verifySigner: async () => true,
+      },
+    })
+    const discovery = await app.request('/v1/agents/test-agent/chat/completions')
+    const body = await discovery.json() as { payment_methods: Array<{ type: string }> }
+    expect(body.payment_methods.map((method) => method.type)).not.toContain('mpp')
+  })
+
+  it('does not serve an agent whose resolver marks it disabled', async () => {
+    const { app } = buildHarness({
+      resolveAgent: async () => makeAgent({ enabled: false }),
+    })
+    const discovery = await app.request('/v1/agents/test-agent/chat/completions')
+    expect(discovery.status).toBe(404)
+
+    const response = await app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': buildSpendAuth() },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+    })
+    expect(response.status).toBe(404)
+  })
 })
 
 describe('POST /:slug/chat/completions — auth paths', () => {

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -89,6 +89,23 @@ describe('verifyX402', () => {
     expect(calls[0].commitment).toBe('0xCommitmentAlice')
   })
 
+  it('does not burn a nonce when signature verification rejects — regression: invalid traffic must not deny a valid payment', async () => {
+    const nonceStore = new MemoryNonceStore()
+    const payload = buildSpendAuth({ nonce: '100' })
+    const rejectedConfig: X402Config = {
+      ...baseConfig,
+      demoMode: false,
+      verifySigner: async () => false,
+    }
+    expect(await verifyX402(payload, rejectedConfig, nonceStore)).toBeNull()
+
+    const acceptedConfig: X402Config = {
+      ...rejectedConfig,
+      verifySigner: async () => true,
+    }
+    expect(await verifyX402(payload, acceptedConfig, nonceStore)).toBe('0xCommitmentAlice')
+  })
+
   it('calls config.verifySigner and accepts on true', async () => {
     const config: X402Config = {
       ...baseConfig,
@@ -111,6 +128,49 @@ describe('verifyMpp', () => {
   it('parses a valid Payment header and returns the signer', async () => {
     const header = buildCredential({ commitment: '0xAlice', operator: operatorAddress, amount: '1000', nonce: '5' })
     expect(await verifyMpp(header, mppConfig, baseConfig)).toBe('0xAlice')
+  })
+
+  it('requires and calls a production MPP verifier, then rejects nonce replay', async () => {
+    const header = buildCredential({
+      commitment: '0xAlice',
+      operator: operatorAddress,
+      amount: '1000',
+      nonce: '6',
+      expiry: String(Math.floor(Date.now() / 1000) + 600),
+    })
+    const seen: Array<{ method: string; credential: string }> = []
+    const config: MppConfig = {
+      ...mppConfig,
+      verifySigner: async (_payload, context) => {
+        seen.push(context)
+        return 'mpp:alice'
+      },
+    }
+    const productionX402: X402Config = { ...baseConfig, demoMode: false }
+    const nonceStore = new MemoryNonceStore()
+
+    expect(await verifyMpp(header, config, productionX402, nonceStore)).toBe('mpp:alice')
+    expect(await verifyMpp(header, config, productionX402, nonceStore)).toBeNull()
+    expect(seen).toHaveLength(1)
+    expect(seen[0].method).toBe('blueprintevm')
+    expect(seen[0].credential).toContain('commitment')
+  })
+
+  it('rejects MPP in production when no method verifier is configured', async () => {
+    const header = buildCredential({ commitment: '0xAlice', operator: operatorAddress })
+    const productionX402: X402Config = { ...baseConfig, demoMode: false }
+    expect(await verifyMpp(header, mppConfig, productionX402)).toBeNull()
+  })
+
+  it('does not reuse the x402 verifier for a different MPP method', async () => {
+    const header = buildCredential({ commitment: '0xAlice', operator: operatorAddress })
+      .replace('Payment blueprintevm ', 'Payment stripe ')
+    const productionX402: X402Config = {
+      ...baseConfig,
+      demoMode: false,
+      verifySigner: async () => true,
+    }
+    expect(await verifyMpp(header, { ...mppConfig, method: 'stripe' }, productionX402)).toBeNull()
   })
 
   it('falls back to the `from` field when no `commitment` present — regression: EIP-3009 wallets expose `from` only', async () => {


### PR DESCRIPTION
## What changed
- require a configured production verifier before accepting API-key or MPP credentials
- keep discovery, A2A cards, and 402 responses aligned with enabled payment methods
- prevent invalid x402/MPP requests from consuming replay nonces
- reject disabled agents at every protocol entry point

## Verification
- `pnpm typecheck`
- `pnpm test` (13 files, 191 tests)
- `pnpm build`

## Release
- bumps package version to `0.7.1`; tag publication follows merge and green CI