### PR TITLE
feat(gateway): expose workspace chat threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ app.route('/v1/agents', createAgentGateway({
 }))
 ```
 
-`x402.verifySigner` is required for production.
+Production requires either `x402.verifySigner` or `verifyApiKey`.
+API-key-only apps can omit `x402` entirely.
 Set `x402.demoMode: true` only for local development and tests; that explicit mode also enables the built-in `sk_agent_*` demo key verifier.
 Keep `verifySigner` free of side effects.
 Use version 2's `authorizePayment` to reserve or claim funds after rate limits, content checks, and product authorization succeed.
@@ -108,6 +109,11 @@ The 0.7.1 `mpp.verifySigner` callback is also supported; the gateway derives a s
 
 The same authentication, authorization, rate-limit, filtering, sandbox, settlement, and usage-recording pipeline is used by the OpenAI-compatible and A2A endpoints.
 Wire protocol handlers only translate their request and response shapes.
+
+Set `conversationMode: 'thread'` when API calls must use the app's visible conversations.
+The gateway accepts an optional `X-Tangle-Thread-Id` and returns the resolved ID in the same response header.
+Its authenticated `getSandbox` context contains that thread ID, the API-key identity, and the filtered messages.
+An `agent-app` host can use this context to drive its normal persisted chat route instead of opening a second sandbox session.
 
 ## A2A protocol
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "packageManager": "pnpm@10.28.0",
   "repository": {
     "type": "git",

--- a/src/dispatch-authorization.ts
+++ b/src/dispatch-authorization.ts
@@ -19,6 +19,7 @@ import {
   defaultVerifyApiKey,
   isApiKeyAuthEnabled,
   isMppAuthEnabled,
+  isX402AuthEnabled,
   mppPaymentPayload,
   mppPaymentCredential,
   verifyMppCredential,
@@ -47,6 +48,18 @@ export async function authenticateAndGuard(
   const requestId = generateRequestId()
   const ctx: RequestContext = { requestId, agentSlug: slug, startMs }
   await state.obs?.onRequestStart?.(ctx)
+
+  let threadId: string | undefined
+  if (config.conversationMode === 'thread') {
+    const requestedThreadId = c.req.header('X-Tangle-Thread-Id')?.trim()
+    if (requestedThreadId && !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(requestedThreadId)) {
+      return c.json(
+        { error: { message: 'Invalid X-Tangle-Thread-Id', type: 'invalid_request' } },
+        { status: 400, headers: { 'X-Request-Id': requestId } },
+      )
+    }
+    threadId = requestedThreadId || requestId
+  }
 
   const agent = await config.resolveAgent(slug)
   if (!agent || !agent.enabled) {
@@ -83,10 +96,14 @@ export async function authenticateAndGuard(
     messages,
     state.maxLen,
   )
-  const userMessage = filtered
+  const userMessages = filtered
     .filter((m) => m.role === 'user')
-    .map((m) => m.content)
-    .join('\n\n')
+  // A thread-backed host already owns the persisted history. Send only the
+  // new turn to avoid storing the caller's full history as one new user row.
+  // Keep the historical concatenation for the default consumer session.
+  const userMessage = config.conversationMode === 'thread'
+    ? userMessages[userMessages.length - 1]?.content ?? ''
+    : userMessages.map((m) => m.content).join('\n\n')
   if (!userMessage) {
     return c.json(
       { error: { message: 'No user message provided', type: 'invalid_request' } },
@@ -176,6 +193,12 @@ export async function authenticateAndGuard(
   let mppPaymentIdentity: string | undefined
 
   if (spendAuthHeader) {
+    if (!isX402AuthEnabled(config)) {
+      return c.json(
+        { error: { message: 'x402 authentication is not configured', type: 'authentication_error' } },
+        { status: 401, headers: { 'X-Request-Id': requestId } },
+      )
+    }
     const signer = await verifyX402(
       spendAuthHeader,
       config.x402,
@@ -301,7 +324,8 @@ export async function authenticateAndGuard(
       code: 'payment_required',
       httpStatus: 402,
     })
-    const methods: string[] = ['x402']
+    const methods: string[] = []
+    if (isX402AuthEnabled(config)) methods.push('x402')
     if (isMppAuthEnabled(config)) methods.push('mpp')
     if (isApiKeyAuthEnabled(config)) methods.push('api_key')
     const headers: Record<string, string> = {
@@ -318,14 +342,18 @@ export async function authenticateAndGuard(
           message: 'Payment required',
           type: 'payment_required',
           payment_methods: methods,
-          x402: {
-            operator: config.x402.operatorAddress,
-            chain_id: config.x402.chainId,
-            credits_address: config.x402.creditsAddress,
-            required_amount: requiredPaymentAmount.toString(),
-            currency_decimals: config.x402.currencyDecimals ?? 6,
-            max_output_tokens: maxOutputTokens,
-          },
+          ...(isX402AuthEnabled(config)
+            ? {
+                x402: {
+                  operator: config.x402.operatorAddress,
+                  chain_id: config.x402.chainId,
+                  credits_address: config.x402.creditsAddress,
+                  required_amount: requiredPaymentAmount.toString(),
+                  currency_decimals: config.x402.currencyDecimals ?? 6,
+                  max_output_tokens: maxOutputTokens,
+                },
+              }
+            : {}),
           ...(isMppAuthEnabled(config) && config.mpp
             ? { mpp: { realm: config.mpp.realm, method: config.mpp.method ?? 'blueprintevm' } }
             : {}),
@@ -399,6 +427,7 @@ export async function authenticateAndGuard(
       consumerId: consumerId,
       keyId: keyInfo?.keyId,
       requestId,
+      ...(threadId ? { threadId } : {}),
     })
     if (!authz.allow) {
       return c.json(
@@ -422,6 +451,8 @@ export async function authenticateAndGuard(
     userMessage,
     rateLimitRemaining: rl.remaining,
     requestId,
+    messages: filtered,
+    ...(threadId ? { threadId } : {}),
     startMs,
     maxOutputTokens,
     executionBudget,

--- a/src/dispatch-sandbox.ts
+++ b/src/dispatch-sandbox.ts
@@ -7,6 +7,7 @@ import {
 import type {
   AgentMeta,
   GatewayConfig,
+  GatewaySandboxContext,
   SandboxExecutionBudget,
   SandboxStreamEvent,
   SandboxUsageReceipt,
@@ -58,9 +59,10 @@ export async function* dispatchSandboxStreamRich(
   onSandboxStart?: () => void | Promise<void>,
   maxInputTokens?: number,
   onExecutionHeartbeat?: () => Promise<void>,
+  sandboxContext?: GatewaySandboxContext,
 ): AsyncIterable<A2ADispatchEvent> {
   if (signal?.aborted) return
-  const box = await config.getSandbox(agent)
+  const box = await config.getSandbox(agent, sandboxContext)
   if (signal?.aborted) return
   const outputLimit = maxOutputTokens ?? config.defaultOutputTokens ?? 1024
   if (!Number.isSafeInteger(outputLimit) || outputLimit <= 0) {

--- a/src/dispatch-types.ts
+++ b/src/dispatch-types.ts
@@ -7,6 +7,7 @@ import type { PaymentSettlementBasis } from './payment-recovery'
 import type {
   AgentMeta,
   ApiKeyInfo,
+  ChatMessage,
   PaymentMethod,
   SandboxExecutionBudget,
   SandboxUsageReceipt,
@@ -37,6 +38,8 @@ export interface AuthorizedRequest {
   userMessage: string
   rateLimitRemaining: number | undefined
   requestId: string
+  messages?: ChatMessage[]
+  threadId?: string
   startMs: number
   maxOutputTokens: number
   executionBudget: SandboxExecutionBudget

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,8 @@ export type {
   SandboxUsageReceipt,
   SandboxStreamEvent,
   SandboxBox,
+  ApiKeyGatewayConfig,
+  CreateAgentGatewayConfig,
   GatewayConfig,
   ChatMessage,
   ChatCompletionRequest,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,8 +23,13 @@ import {
   assertPaymentRecoveryConfig,
 } from './payment-recovery'
 import { MemoryRateLimitStore, type RateLimitStore } from './rate-limit'
-import type { ChatCompletionChunk, ChatCompletionRequest, GatewayConfig } from './types'
-import { isApiKeyAuthEnabled, isMppAuthEnabled } from './verify'
+import type {
+  ChatCompletionChunk,
+  ChatCompletionRequest,
+  CreateAgentGatewayConfig,
+  GatewayConfig,
+} from './types'
+import { isApiKeyAuthEnabled, isMppAuthEnabled, isX402AuthEnabled } from './verify'
 
 /**
  * Create a Hono router that serves the agent gateway.
@@ -36,13 +41,19 @@ import { isApiKeyAuthEnabled, isMppAuthEnabled } from './verify'
  *   GET  /:slug/chat/completions  — agent discovery metadata (Tangle-native shape)
  *   POST /:slug/chat/completions  — OpenAI-compatible chat endpoint (paid)
  */
-export function createAgentGateway(inputConfig: GatewayConfig) {
-  let config = inputConfig
+export function createAgentGateway(inputConfig: CreateAgentGatewayConfig) {
+  let config: GatewayConfig = inputConfig.x402
+    ? inputConfig
+    : {
+        ...inputConfig,
+        x402: { operatorAddress: '', chainId: 0 },
+      }
   // Production gateways must verify x402 signatures. Tests and local
   // dev can opt into the explicit demo path.
-  if (!config.x402.verifySigner && !config.x402.demoMode) {
+  if (!isX402AuthEnabled(config) && !config.verifyApiKey) {
     throw new Error(
-      'createAgentGateway: x402.verifySigner is required in production. ' +
+      'createAgentGateway: verifySigner is required in production unless verifyApiKey is configured; ' +
+        'configure x402.verifySigner or verifyApiKey. ' +
         'For tests, set x402.demoMode: true explicitly.',
     )
   }
@@ -185,14 +196,15 @@ export function createAgentGateway(inputConfig: GatewayConfig) {
     const agent = await config.resolveAgent(slug)
     if (!agent || !agent.enabled) return c.json({ error: 'Agent not found or not published' }, 404)
 
-    const paymentMethods: Array<Record<string, unknown>> = [
-      {
+    const paymentMethods: Array<Record<string, unknown>> = []
+    if (isX402AuthEnabled(config)) {
+      paymentMethods.push({
         type: 'x402',
         operator: config.x402.operatorAddress,
         chain_id: config.x402.chainId,
         credits_contract: config.x402.creditsAddress,
-      },
-    ]
+      })
+    }
     if (isMppAuthEnabled(config)) {
       paymentMethods.push({
         type: 'mpp',
@@ -200,7 +212,9 @@ export function createAgentGateway(inputConfig: GatewayConfig) {
         method: config.mpp!.method ?? 'blueprintevm',
       })
     }
-    if (isApiKeyAuthEnabled(config)) paymentMethods.push({ type: 'api_key', prefix: 'sk_agent_' })
+    if (isApiKeyAuthEnabled(config)) {
+      paymentMethods.push({ type: 'api_key', prefix: config.apiKeyPrefix ?? 'sk_agent_' })
+    }
 
     return c.json({
       slug: agent.slug,
@@ -412,7 +426,7 @@ function streamChatCompletions(
           consumerId,
           config,
           abortController.signal,
-          undefined,
+          authz.threadId,
           maxOutputTokens,
           () => beginPaymentExecution(authz, config),
           authz.paymentOperation !== undefined || authz.mppChargeOperation !== undefined,
@@ -422,6 +436,14 @@ function streamChatCompletions(
           },
           authz.executionBudget.maxInputTokens,
           () => renewPaymentExecution(authz, config),
+          {
+            consumerId,
+            paymentMethod,
+            keyInfo: authz.keyInfo,
+            requestId,
+            messages: authz.messages ?? [],
+            ...(authz.threadId ? { threadId: authz.threadId } : {}),
+          },
         )) {
           if (event.kind === 'text') {
             sendChunk(event.delta)
@@ -499,6 +521,7 @@ function streamChatCompletions(
       'X-Request-Id': requestId,
       'X-Agent-Slug': agent.slug,
       'X-Agent-Hosting': agent.sandboxEndpoint ? 'sovereign' : 'centralized',
+      ...(authz.threadId ? { 'X-Tangle-Thread-Id': authz.threadId } : {}),
       'X-Payment-Method': paymentMethod,
       'X-Payment-Settled': paymentMethod === 'x402' || authz.paymentOperation ? 'pending' : 'true',
       ...(authz.mppChargeOperation

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,14 +225,28 @@ export interface SandboxBox {
   ): AsyncIterable<SandboxStreamEvent>
 }
 
+/** Authenticated request identity supplied when the host resolves a sandbox. */
+export interface GatewaySandboxContext {
+  consumerId: string
+  paymentMethod: PaymentMethod
+  keyInfo: ApiKeyInfo | null
+  requestId: string
+  messages: ChatMessage[]
+  /** Stable UI conversation id when `conversationMode` is `thread`. */
+  threadId?: string
+}
+
 // --- Gateway config ---
 
 export interface GatewayConfig {
   /** Resolve agent metadata by slug. Return null if not found or not published. */
   resolveAgent: (slug: string) => Promise<AgentMeta | null>
 
-  /** Get a sandbox instance for the agent. Called after payment is verified. */
-  getSandbox: (agent: AgentMeta) => Promise<SandboxBox>
+  /**
+   * Get the agent execution adapter after payment is verified.
+   * Hosts that use agent-app can drive their normal persisted chat route here.
+   */
+  getSandbox: (agent: AgentMeta, context?: GatewaySandboxContext) => Promise<SandboxBox>
 
   /**
    * Optional host authorization hook fired after payment verification
@@ -241,7 +255,14 @@ export interface GatewayConfig {
    */
   authorizeConsumer?: (
     agent: AgentMeta,
-    consumer: { method: PaymentMethod; consumerId: string; keyId?: string; requestId: string },
+    consumer: {
+      method: PaymentMethod
+      consumerId: string
+      keyId?: string
+      requestId: string
+      /** Requested stable conversation id, after syntax validation. */
+      threadId?: string
+    },
   ) => Promise<{ allow: true } | { allow: false; reason: string; code: string }>
 
   /**
@@ -282,6 +303,16 @@ export interface GatewayConfig {
 
   /** Base URL for API key purchase links (e.g. "https://film.tangle.tools") */
   baseUrl?: string
+
+  /** Public API key prefix shown by discovery. Defaults to `sk_agent_`. */
+  apiKeyPrefix?: string
+
+  /**
+   * `consumer` keeps the historical session per API consumer.
+   * `thread` accepts `X-Tangle-Thread-Id` or creates one per request and returns
+   * it in the response, so a host can display the same conversation.
+   */
+  conversationMode?: 'consumer' | 'thread'
 
   /** Max message length in chars (default: 8000) */
   maxMessageLength?: number
@@ -391,6 +422,16 @@ export interface GatewayConfig {
     pushUrlValidator?: (url: URL) => boolean | Promise<boolean>
   }
 }
+
+/** API-key-only gateway input. Payment transports stay disabled. */
+export type ApiKeyGatewayConfig = Omit<GatewayConfig, 'mpp' | 'verifyApiKey' | 'x402'> & {
+  mpp?: never
+  verifyApiKey: NonNullable<GatewayConfig['verifyApiKey']>
+  x402?: never
+}
+
+/** Configuration accepted by `createAgentGateway`. */
+export type CreateAgentGatewayConfig = GatewayConfig | ApiKeyGatewayConfig
 
 // --- Chat completion types (OpenAI-compatible) ---
 

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -108,6 +108,13 @@ export function isApiKeyAuthEnabled(
   return config.verifyApiKey !== undefined || config.x402.demoMode === true
 }
 
+/** x402 is advertised only when the gateway can authenticate it. */
+export function isX402AuthEnabled(
+  config: Pick<GatewayConfig, 'x402'>,
+): boolean {
+  return config.x402.verifySigner !== undefined || config.x402.demoMode === true
+}
+
 /** MPP is enabled only when authentication and method settlement are complete. */
 export function isMppAuthEnabled(
   config: Pick<GatewayConfig, 'mpp' | 'x402'>,

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -15,6 +15,7 @@ import type {
   SandboxStreamEvent,
   GatewayUsageEvent,
   ApiKeyInfo,
+  GatewaySandboxContext,
 } from '../src/types'
 import { MemoryNonceStore, type NonceStore } from '../src/nonce-store'
 import { MemoryRateLimitStore } from '../src/rate-limit'
@@ -258,6 +259,27 @@ describe('GET /:slug/chat/completions (discovery)', () => {
     expect(response.status).toBe(401)
   })
 
+  it('supports production API-key-only gateways without advertising x402', async () => {
+    const sandbox = new StubSandbox(['api only'])
+    const gateway = createAgentGateway({
+      resolveAgent: async (slug) => slug === 'test-agent' ? makeAgent() : null,
+      getSandbox: async () => sandbox,
+      recordUsage: async () => undefined,
+      verifyApiKey: async () => ({
+        consumerId: 'api-consumer',
+        keyId: 'api-key',
+        scopes: ['chat'],
+      }),
+    })
+    const app = new Hono().route('/v1/agents', gateway)
+
+    const response = await app.request('/v1/agents/test-agent/chat/completions')
+    const body = await response.json() as { payment_methods: Array<{ type: string }> }
+
+    expect(response.status).toBe(200)
+    expect(body.payment_methods.map((method) => method.type)).toEqual(['api_key'])
+  })
+
   it('rejects an MPP method without a compatible verifier at gateway construction', () => {
     expect(() => buildHarness({
       mpp: { realm: 'agents.tangle.tools', method: 'stripe' },
@@ -349,6 +371,92 @@ describe('GET /:slug/chat/completions (discovery)', () => {
 })
 
 describe('POST /:slug/chat/completions — auth paths', () => {
+  it('returns the UI thread id and supplies the authenticated request to the host adapter', async () => {
+    let executionContext: GatewaySandboxContext | undefined
+    const sandbox = new StubSandbox(['threaded'])
+    const { app } = buildHarness({
+      conversationMode: 'thread',
+      x402: { operatorAddress, chainId: 3799 },
+      verifyApiKey: async () => ({
+        consumerId: 'api-consumer',
+        keyId: 'api-key',
+        scopes: ['chat'],
+      }),
+      getSandbox: async (_agent, context) => {
+        executionContext = context
+        return sandbox
+      },
+    })
+
+    const response = await app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer agent-key',
+      },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'do real work' }] }),
+    })
+    const threadId = response.headers.get('X-Tangle-Thread-Id')
+    const streamed = await readSse(response)
+
+    expect(response.status).toBe(200)
+    expect(threadId).toMatch(/^[A-Za-z0-9][A-Za-z0-9._:-]+$/)
+    expect(streamed.combinedText).toBe('threaded')
+    expect(executionContext).toMatchObject({
+      consumerId: 'api-consumer',
+      paymentMethod: 'apikey',
+      requestId: threadId,
+      threadId,
+      messages: [{ role: 'user', content: 'do real work' }],
+      keyInfo: { keyId: 'api-key' },
+    })
+    expect(sandbox.receivedOpts?.sessionId).toBe(threadId)
+  })
+
+  it('continues a requested UI thread and rejects unsafe thread ids', async () => {
+    const { app } = buildHarness({ conversationMode: 'thread' })
+    const request = (threadId: string) => app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer sk_agent_thread',
+        'X-Tangle-Thread-Id': threadId,
+      },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'continue' }] }),
+    })
+
+    const continued = await request('thread-existing-1')
+    await continued.text()
+    const rejected = await request('../another workspace')
+
+    expect(continued.headers.get('X-Tangle-Thread-Id')).toBe('thread-existing-1')
+    expect(rejected.status).toBe(400)
+  })
+
+  it('sends only the newest user turn to a thread-backed sandbox', async () => {
+    const { app, sandbox } = buildHarness({ conversationMode: 'thread' })
+    const response = await app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer sk_agent_thread-history',
+        'X-Tangle-Thread-Id': 'thread-history-1',
+      },
+      body: JSON.stringify({
+        messages: [
+          { role: 'user', content: 'first question' },
+          { role: 'assistant', content: 'first answer' },
+          { role: 'user', content: 'latest question' },
+        ],
+      }),
+    })
+
+    await readSse(response)
+
+    expect(response.status).toBe(200)
+    expect(sandbox.receivedPrompt).toBe('latest question')
+  })
+
   it('returns 402 when no payment header present — regression: free rides would drain compute', async () => {
     const { app } = buildHarness()
     const res = await app.request('/v1/agents/test-agent/chat/completions', {
@@ -1060,6 +1168,30 @@ describe('POST /:slug/chat/completions — injection blocking', () => {
 })
 
 describe('POST /:slug/chat/completions — authorizeConsumer hook', () => {
+  it('passes the validated thread id to host authorization before sandbox lookup', async () => {
+    let authorizedThread: string | undefined
+    const { app } = buildHarness({
+      conversationMode: 'thread',
+      authorizeConsumer: async (_agent, consumer) => {
+        authorizedThread = consumer.threadId
+        return { allow: false, reason: 'thread not owned by consumer', code: 'thread_not_owned' }
+      },
+    })
+
+    const response = await app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer sk_agent_thread-owner',
+        'X-Tangle-Thread-Id': 'thread-owned-by-someone-else',
+      },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'continue' }] }),
+    })
+
+    expect(response.status).toBe(403)
+    expect(authorizedThread).toBe('thread-owned-by-someone-else')
+  })
+
   it('blocks consumers an authorizeConsumer hook denies — regression: hosts must be able to allowlist', async () => {
     const calls: Array<{ agentId: string; consumerId: string; requestId: string }> = []
     const { app } = buildHarness({
@@ -1178,7 +1310,7 @@ describe('createAgentGateway — production-config guard', () => {
       getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
       recordUsage: async () => { /* unused */ },
       x402: { operatorAddress, chainId: 3799 }, // no verifySigner, no demoMode
-    })).toThrow(/verifySigner is required in production/)
+    })).toThrow(/configure x402\.verifySigner or verifyApiKey/)
   })
 
   it('boots when demoMode: true is set explicitly (test path)', () => {


### PR DESCRIPTION
## Outcome

- allow production API-key-only gateways without fake x402 configuration
- pass authenticated API identity and stable thread IDs to the host adapter
- keep one OpenAI-compatible request on the app workspace thread
- expose the resolved thread ID in the response

## Proof

- `pnpm typecheck`
- `pnpm test` (373 passed)
- `pnpm build`