### PR TITLE
fix(release): restore npm token publishing for 0.8.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,11 +66,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
 
-      - name: Configure npm trusted publishing
-        run: |
-          npm install --global npm@^11.5.1
-          sed -i '/_authToken/d' "$HOME/.npmrc" 2>/dev/null || true
-
       # Idempotent: re-running a tag whose npm version is already published
       # must not fail the workflow.
       - name: Publish to npm (skip if already published)
@@ -82,3 +77,5 @@ jobs:
           else
             pnpm publish --no-git-checks --access public --provenance
           fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "packageManager": "pnpm@10.28.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem
The v0.8.3 tag removed NODE_AUTH_TOKEN while npm trusted publishing is not configured, so the release job signed provenance and failed with E404.

## Change
- Restore NODE_AUTH_TOKEN from secrets.NPM_TOKEN on the publish step.
- Remove the unconfigured trusted-publishing setup step.
- Bump package version to 0.8.4 because 0.8.3 was never published.

## Verification
- pnpm install --frozen-lockfile
- pnpm run typecheck
- pnpm run test (378 passed)
- pnpm run build

The existing id-token: write permission and --provenance flag remain enabled.