### PR TITLE
fix(a2a): preserve thread context and stream liveness

### DIFF
--- a/src/a2a/handler.ts
+++ b/src/a2a/handler.ts
@@ -317,6 +317,7 @@ async function guardMessageRequest(
   }
 
   let billingMessages: ChatMessage[] = [{ role: 'user', content: extracted.text }]
+  let knownTaskContextId: string | undefined
   if (typeof params.message.taskId === 'string') {
     const storedForQuote = await deps.taskStore.get(params.message.taskId)
     if (storedForQuote) {
@@ -329,8 +330,16 @@ async function guardMessageRequest(
           { role: 'user', content: extracted.text },
         ]
       }
+      knownTaskContextId = quotedTask.contextId
     }
   }
+
+  const messageContextId = typeof params.message.contextId === 'string'
+    ? params.message.contextId
+    : undefined
+  const requestedThreadId = deps.config.conversationMode === 'thread'
+    ? knownTaskContextId ?? messageContextId
+    : undefined
 
   const guard = await authenticateAndGuard(
     c,
@@ -338,6 +347,8 @@ async function guardMessageRequest(
     billingMessages,
     deps.config,
     deps.state,
+    undefined,
+    requestedThreadId,
   )
   if (guard instanceof Response) return guard
   const authz = guard
@@ -391,7 +402,11 @@ async function guardMessageRequest(
   }
 
   const taskId = params.message.taskId ?? `task_${cryptoRandomId()}`
-  const contextId = params.message.contextId ?? `ctx_${cryptoRandomId()}`
+  const contextId = knownTaskContextId ?? (
+    deps.config.conversationMode === 'thread'
+      ? authz.threadId ?? `ctx_${cryptoRandomId()}`
+      : messageContextId ?? `ctx_${cryptoRandomId()}`
+  )
   const initialMessage = {
     ...params.message,
     taskId,

--- a/src/a2a/message-send-execution.ts
+++ b/src/a2a/message-send-execution.ts
@@ -77,9 +77,6 @@ export async function executeMessageSend(
   let inputRequiredPrompt: string | undefined
   let inputRequiredSeen = false
   let finalizationLeaseId: string | undefined
-  const sandboxContext = deps.config.conversationMode === 'thread'
-    ? buildGatewaySandboxContext(authz, authz.threadId)
-    : undefined
   try {
     for await (const event of dispatchSandboxStreamRich(
       authz.agent,
@@ -103,7 +100,7 @@ export async function executeMessageSend(
         workingTask = await renewTaskExecution(deps.taskStore, task.id, authz.requestId)
         await renewPaymentExecution(authz, deps.config)
       },
-      sandboxContext,
+      buildGatewaySandboxContext(authz),
     )) {
       if (event.kind === 'text') {
         responseText += event.delta

--- a/src/a2a/message-send-execution.ts
+++ b/src/a2a/message-send-execution.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono'
 import {
   type AuthorizedRequest,
   dispatchSandboxStreamRich,
+  buildGatewaySandboxContext,
   beginPaymentExecution,
   markPaymentExecutionStarted,
   renewPaymentExecution,
@@ -76,6 +77,9 @@ export async function executeMessageSend(
   let inputRequiredPrompt: string | undefined
   let inputRequiredSeen = false
   let finalizationLeaseId: string | undefined
+  const sandboxContext = deps.config.conversationMode === 'thread'
+    ? buildGatewaySandboxContext(authz, authz.threadId)
+    : undefined
   try {
     for await (const event of dispatchSandboxStreamRich(
       authz.agent,
@@ -99,6 +103,7 @@ export async function executeMessageSend(
         workingTask = await renewTaskExecution(deps.taskStore, task.id, authz.requestId)
         await renewPaymentExecution(authz, deps.config)
       },
+      sandboxContext,
     )) {
       if (event.kind === 'text') {
         responseText += event.delta

--- a/src/a2a/message-stream-execution.ts
+++ b/src/a2a/message-stream-execution.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono'
 import {
   type AuthorizedRequest,
   beginPaymentExecution,
+  buildGatewaySandboxContext,
   dispatchSandboxStreamRich,
   markPaymentExecutionStarted,
   renewPaymentExecution,
@@ -95,6 +96,9 @@ export async function executeMessageStream(
   let responseText = ''
   let usage: SandboxUsageReceipt | undefined
   let workObserved = false
+  const sandboxContext = deps.config.conversationMode === 'thread'
+    ? buildGatewaySandboxContext(authz, authz.threadId)
+    : undefined
 
   const stream = new ReadableStream({
     start(ctrl) {
@@ -137,6 +141,7 @@ export async function executeMessageStream(
               workingTask = await renewTaskExecution(deps.taskStore, task.id, authz.requestId)
               await renewPaymentExecution(authz, deps.config)
             },
+            sandboxContext,
           )) {
             if (event.kind === 'text') {
               responseText += event.delta

--- a/src/a2a/message-stream-execution.ts
+++ b/src/a2a/message-stream-execution.ts
@@ -96,9 +96,6 @@ export async function executeMessageStream(
   let responseText = ''
   let usage: SandboxUsageReceipt | undefined
   let workObserved = false
-  const sandboxContext = deps.config.conversationMode === 'thread'
-    ? buildGatewaySandboxContext(authz, authz.threadId)
-    : undefined
 
   const stream = new ReadableStream({
     start(ctrl) {
@@ -141,7 +138,7 @@ export async function executeMessageStream(
               workingTask = await renewTaskExecution(deps.taskStore, task.id, authz.requestId)
               await renewPaymentExecution(authz, deps.config)
             },
-            sandboxContext,
+            buildGatewaySandboxContext(authz),
           )) {
             if (event.kind === 'text') {
               responseText += event.delta

--- a/src/dispatch-authorization.ts
+++ b/src/dispatch-authorization.ts
@@ -35,6 +35,8 @@ import {
  * Body parsing is the caller's responsibility — different wire formats
  * (OpenAI chat completions vs A2A JSON-RPC) have different envelopes; both
  * still ultimately produce a `ChatMessage[]`.
+ * A2A may provide its durable context ID so authorization and adapter access
+ * use the same thread identity.
  */
 export async function authenticateAndGuard(
   c: Context,
@@ -43,6 +45,7 @@ export async function authenticateAndGuard(
   config: GatewayConfig,
   state: GatewayState,
   requestedMaxOutputTokens?: number,
+  requestedThreadId?: string,
 ): Promise<AuthorizedRequest | Response> {
   const startMs = Date.now()
   const requestId = generateRequestId()
@@ -51,14 +54,28 @@ export async function authenticateAndGuard(
 
   let threadId: string | undefined
   if (config.conversationMode === 'thread') {
-    const requestedThreadId = c.req.header('X-Tangle-Thread-Id')?.trim()
-    if (requestedThreadId && !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(requestedThreadId)) {
+    const headerThreadId = c.req.header('X-Tangle-Thread-Id')?.trim()
+    const requestedContextThreadId = typeof requestedThreadId === 'string'
+      ? requestedThreadId.trim()
+      : undefined
+    if (
+      headerThreadId &&
+      requestedContextThreadId &&
+      headerThreadId !== requestedContextThreadId
+    ) {
+      return c.json(
+        { error: { message: 'Thread identity does not match A2A context', type: 'invalid_request' } },
+        { status: 400, headers: { 'X-Request-Id': requestId } },
+      )
+    }
+    const requestedThread = headerThreadId || requestedContextThreadId
+    if (requestedThread && !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(requestedThread)) {
       return c.json(
         { error: { message: 'Invalid X-Tangle-Thread-Id', type: 'invalid_request' } },
         { status: 400, headers: { 'X-Request-Id': requestId } },
       )
     }
-    threadId = requestedThreadId || requestId
+    threadId = requestedThread || requestId
   }
 
   const agent = await config.resolveAgent(slug)

--- a/src/dispatch-sandbox.ts
+++ b/src/dispatch-sandbox.ts
@@ -1,5 +1,5 @@
 import { redactSystemPromptFromOutput } from './filter'
-import type { A2ADispatchEvent } from './dispatch-types'
+import type { A2ADispatchEvent, AuthorizedRequest } from './dispatch-types'
 import {
   estimateTokens,
   maximumBillableInputTokens,
@@ -12,6 +12,21 @@ import type {
   SandboxStreamEvent,
   SandboxUsageReceipt,
 } from './types'
+
+/** Build the adapter context from the request's authenticated identity. */
+export function buildGatewaySandboxContext(
+  authz: Pick<AuthorizedRequest, 'consumerId' | 'paymentMethod' | 'keyInfo' | 'requestId' | 'messages'>,
+  threadId?: string,
+): GatewaySandboxContext {
+  return {
+    consumerId: authz.consumerId,
+    paymentMethod: authz.paymentMethod,
+    keyInfo: authz.keyInfo,
+    requestId: authz.requestId,
+    messages: authz.messages ?? [],
+    ...(threadId !== undefined ? { threadId } : {}),
+  }
+}
 
 export async function* dispatchSandboxStream(
   agent: AgentMeta,

--- a/src/dispatch-sandbox.ts
+++ b/src/dispatch-sandbox.ts
@@ -15,8 +15,7 @@ import type {
 
 /** Build the adapter context from the request's authenticated identity. */
 export function buildGatewaySandboxContext(
-  authz: Pick<AuthorizedRequest, 'consumerId' | 'paymentMethod' | 'keyInfo' | 'requestId' | 'messages'>,
-  threadId?: string,
+  authz: AuthorizedRequest,
 ): GatewaySandboxContext {
   return {
     consumerId: authz.consumerId,
@@ -24,7 +23,7 @@ export function buildGatewaySandboxContext(
     keyInfo: authz.keyInfo,
     requestId: authz.requestId,
     messages: authz.messages ?? [],
-    ...(threadId !== undefined ? { threadId } : {}),
+    ...(authz.threadId !== undefined ? { threadId: authz.threadId } : {}),
   }
 }
 

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -31,6 +31,7 @@ export {
 } from './dispatch-payment'
 
 export {
+  buildGatewaySandboxContext,
   dispatchSandboxStream,
   dispatchSandboxStreamRich,
 } from './dispatch-sandbox'

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ export type {
   SandboxUsageReceipt,
   SandboxStreamEvent,
   SandboxBox,
+  GatewaySandboxContext,
   ApiKeyGatewayConfig,
   CreateAgentGatewayConfig,
   GatewayConfig,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -423,6 +423,7 @@ function streamChatCompletions(
         if (controller.desiredSize === null) return
         controller.enqueue(encoder.encode(': keep-alive\n\n'))
       }
+      const keepaliveTimer = setInterval(sendKeepalive, 15_000)
 
       try {
         sendChunk('', 'assistant')
@@ -448,10 +449,7 @@ function streamChatCompletions(
             sendChunk(event.delta)
             workObserved = true
           }
-          if (event.kind === 'activity') {
-            sendKeepalive()
-            workObserved = true
-          }
+          if (event.kind === 'activity') workObserved = true
           if (event.kind === 'usage') usage = event.usage
         }
 
@@ -507,6 +505,7 @@ function streamChatCompletions(
           )
         }
       } finally {
+        clearInterval(keepaliveTimer)
         requestSignal.removeEventListener('abort', abortFromRequest)
         if (controller.desiredSize !== null) controller.close()
       }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -407,7 +407,7 @@ function streamChatCompletions(
   const stream = new ReadableStream({
     async start(controller) {
       const encoder = new TextEncoder()
-      const sendChunk = (delta: string) => {
+      const sendChunk = (delta: string, role?: string) => {
         if (controller.desiredSize === null) return
         outputText += delta
         const chunk: ChatCompletionChunk = {
@@ -415,12 +415,17 @@ function streamChatCompletions(
           object: 'chat.completion.chunk',
           created: Math.floor(Date.now() / 1000),
           model: agent.slug,
-          choices: [{ index: 0, delta: { content: delta }, finish_reason: null }],
+          choices: [{ index: 0, delta: role ? { role } : { content: delta }, finish_reason: null }],
         }
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`))
       }
+      const sendKeepalive = () => {
+        if (controller.desiredSize === null) return
+        controller.enqueue(encoder.encode(': keep-alive\n\n'))
+      }
 
       try {
+        sendChunk('', 'assistant')
         for await (const event of dispatchSandboxStreamRich(
           agent,
           userMessage,
@@ -437,13 +442,16 @@ function streamChatCompletions(
           },
           authz.executionBudget.maxInputTokens,
           () => renewPaymentExecution(authz, config),
-          buildGatewaySandboxContext(authz, authz.threadId),
+          buildGatewaySandboxContext(authz),
         )) {
           if (event.kind === 'text') {
             sendChunk(event.delta)
             workObserved = true
           }
-          if (event.kind === 'activity') workObserved = true
+          if (event.kind === 'activity') {
+            sendKeepalive()
+            workObserved = true
+          }
           if (event.kind === 'usage') usage = event.usage
         }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,7 @@ import {
   markPaymentExecutionStarted,
   renewPaymentExecution,
   claimPayment,
+  buildGatewaySandboxContext,
   dispatchSandboxStreamRich,
   releasePayment,
   releasePaymentAfterFailure,
@@ -436,14 +437,7 @@ function streamChatCompletions(
           },
           authz.executionBudget.maxInputTokens,
           () => renewPaymentExecution(authz, config),
-          {
-            consumerId,
-            paymentMethod,
-            keyInfo: authz.keyInfo,
-            requestId,
-            messages: authz.messages ?? [],
-            ...(authz.threadId ? { threadId: authz.threadId } : {}),
-          },
+          buildGatewaySandboxContext(authz, authz.threadId),
         )) {
           if (event.kind === 'text') {
             sendChunk(event.delta)

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -24,6 +24,7 @@ import type {
   AgentMeta,
   ApiKeyInfo,
   GatewayConfig,
+  GatewaySandboxContext,
   GatewayUsageEvent,
   SandboxBox,
   SandboxStreamEvent,
@@ -146,13 +147,14 @@ function apiKeyHeader(): Record<string, string> {
   return { Authorization: 'Bearer sk_agent_test_key_1' }
 }
 
-function textMessage(text: string, taskId?: string) {
+function textMessage(text: string, taskId?: string, contextId?: string) {
   return {
     kind: 'message' as const,
     role: 'user' as const,
     parts: [{ kind: 'text' as const, text }],
     messageId: `msg_${Math.random().toString(36).slice(2)}`,
     ...(taskId ? { taskId } : {}),
+    ...(contextId ? { contextId } : {}),
   }
 }
 
@@ -427,6 +429,123 @@ describe('A2A — message/stream', () => {
     // Settlement + usage fire after stream completes.
     expect(harness.usage).toHaveLength(1)
     expect(harness.settlements).toHaveLength(1)
+  })
+})
+
+describe('A2A — authenticated sandbox context', () => {
+  it('passes task identity and authenticated context to send and stream adapters', async () => {
+    const contexts: Array<GatewaySandboxContext | undefined> = []
+    const authorizedThreads: Array<string | undefined> = []
+    const calls: Array<{ message: string; sessionId?: string }> = []
+    const sandbox: SandboxBox = {
+      async *streamPrompt(message, opts) {
+        calls.push({ message, ...(opts?.sessionId ? { sessionId: opts.sessionId } : {}) })
+        yield { type: 'message.part.updated', data: { part: { type: 'text' }, delta: 'done' } }
+        yield {
+          type: 'sandbox.usage',
+          data: {
+            usage: {
+              inputTokens: 1,
+              outputTokens: 1,
+              reasoningTokens: 0,
+              toolTokens: 0,
+              toolCallCount: 0,
+              providerCostUsd: 0.00004,
+              budgetEnforced: true,
+            },
+          },
+        }
+      },
+    }
+    const harness = buildHarness({
+      conversationMode: 'thread',
+      authorizeConsumer: async (_agent, consumer) => {
+        authorizedThreads.push(consumer.threadId)
+        return { allow: true }
+      },
+      getSandbox: async (_agent, context) => {
+        contexts.push(context)
+        return sandbox
+      },
+    })
+
+    const sendResponse = await postJsonRpc(
+      harness.app,
+      'test-agent',
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: { message: textMessage('send', 'send-task', 'send-context') },
+      },
+      apiKeyHeader(),
+    )
+    expect(sendResponse.status).toBe(200)
+    await sendResponse.text()
+
+    const streamResponse = await postJsonRpc(
+      harness.app,
+      'test-agent',
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'message/stream',
+        params: { message: textMessage('stream', 'stream-task', 'stream-context') },
+      },
+      apiKeyHeader(),
+    )
+    expect(streamResponse.status).toBe(200)
+    await parseSseEvents(streamResponse)
+
+    expect(contexts).toHaveLength(2)
+    expect(authorizedThreads).toEqual(['send-context', 'stream-context'])
+    expect(contexts[0]).toMatchObject({
+      consumerId: 'consumer_sk_agent_test_key_1',
+      paymentMethod: 'apikey',
+      keyInfo: { keyId: 'sk_agent_test_key_1' },
+      messages: [{ role: 'user', content: 'send' }],
+      threadId: 'send-context',
+    })
+    expect(contexts[1]).toMatchObject({
+      consumerId: 'consumer_sk_agent_test_key_1',
+      paymentMethod: 'apikey',
+      keyInfo: { keyId: 'sk_agent_test_key_1' },
+      messages: [{ role: 'user', content: 'stream' }],
+      threadId: 'stream-context',
+    })
+    expect(calls).toEqual([
+      { message: 'send', sessionId: 'send-task' },
+      { message: 'stream', sessionId: 'stream-task' },
+    ])
+  })
+
+  it('rejects a header thread that disagrees with the A2A context before sandbox access', async () => {
+    let sandboxAccesses = 0
+    const harness = buildHarness({
+      conversationMode: 'thread',
+      getSandbox: async () => {
+        sandboxAccesses += 1
+        return new StubSandbox(['unreachable'])
+      },
+    })
+
+    const response = await postJsonRpc(
+      harness.app,
+      'test-agent',
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: { message: textMessage('send', 'mismatch-task', 'a2a-context') },
+      },
+      { ...apiKeyHeader(), 'X-Tangle-Thread-Id': 'header-context' },
+    )
+
+    expect(response.status).toBe(400)
+    expect(sandboxAccesses).toBe(0)
+    expect(await response.json()).toMatchObject({
+      error: { message: 'Thread identity does not match A2A context' },
+    })
   })
 })
 

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -469,54 +469,39 @@ describe('A2A — authenticated sandbox context', () => {
       },
     })
 
-    const sendResponse = await postJsonRpc(
-      harness.app,
-      'test-agent',
-      {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'message/send',
-        params: { message: textMessage('send', 'send-task', 'send-context') },
-      },
-      apiKeyHeader(),
-    )
-    expect(sendResponse.status).toBe(200)
-    await sendResponse.text()
+    const requests = [
+      { id: 1, method: 'message/send' as const, text: 'send', taskId: 'send-task', contextId: 'send-context' },
+      { id: 2, method: 'message/stream' as const, text: 'stream', taskId: 'stream-task', contextId: 'stream-context' },
+    ]
+    for (const request of requests) {
+      const response = await postJsonRpc(
+        harness.app,
+        'test-agent',
+        {
+          jsonrpc: '2.0',
+          id: request.id,
+          method: request.method,
+          params: { message: textMessage(request.text, request.taskId, request.contextId) },
+        },
+        apiKeyHeader(),
+      )
+      expect(response.status).toBe(200)
+      if (request.method === 'message/send') await response.text()
+      else await parseSseEvents(response)
+    }
 
-    const streamResponse = await postJsonRpc(
-      harness.app,
-      'test-agent',
-      {
-        jsonrpc: '2.0',
-        id: 2,
-        method: 'message/stream',
-        params: { message: textMessage('stream', 'stream-task', 'stream-context') },
-      },
-      apiKeyHeader(),
-    )
-    expect(streamResponse.status).toBe(200)
-    await parseSseEvents(streamResponse)
-
-    expect(contexts).toHaveLength(2)
-    expect(authorizedThreads).toEqual(['send-context', 'stream-context'])
-    expect(contexts[0]).toMatchObject({
-      consumerId: 'consumer_sk_agent_test_key_1',
-      paymentMethod: 'apikey',
-      keyInfo: { keyId: 'sk_agent_test_key_1' },
-      messages: [{ role: 'user', content: 'send' }],
-      threadId: 'send-context',
-    })
-    expect(contexts[1]).toMatchObject({
-      consumerId: 'consumer_sk_agent_test_key_1',
-      paymentMethod: 'apikey',
-      keyInfo: { keyId: 'sk_agent_test_key_1' },
-      messages: [{ role: 'user', content: 'stream' }],
-      threadId: 'stream-context',
-    })
-    expect(calls).toEqual([
-      { message: 'send', sessionId: 'send-task' },
-      { message: 'stream', sessionId: 'stream-task' },
-    ])
+    expect(contexts).toHaveLength(requests.length)
+    expect(authorizedThreads).toEqual(requests.map(({ contextId }) => contextId))
+    expect(calls).toEqual(requests.map(({ text, taskId }) => ({ message: text, sessionId: taskId })))
+    for (const [index, request] of requests.entries()) {
+      expect(contexts[index]).toMatchObject({
+        consumerId: 'consumer_sk_agent_test_key_1',
+        paymentMethod: 'apikey',
+        keyInfo: { keyId: 'sk_agent_test_key_1' },
+        messages: [{ role: 'user', content: request.text }],
+        threadId: request.contextId,
+      })
+    }
   })
 
   it('rejects a header thread that disagrees with the A2A context before sandbox access', async () => {

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -519,6 +519,44 @@ describe('POST /:slug/chat/completions — auth paths', () => {
     expect(usage[0]?.outputTokens).toBe(2)
   })
 
+  it('emits an assistant role and keepalive for activity-only sandbox work', async () => {
+    const sandbox: SandboxBox = {
+      async *streamPrompt() {
+        yield { type: 'tool.started', data: { tool: { name: 'workspace-search' } } }
+        yield { type: 'sandbox.usage', data: { usage: {
+          inputTokens: 1,
+          outputTokens: 0,
+          reasoningTokens: 0,
+          toolTokens: 0,
+          toolCallCount: 1,
+          providerCostUsd: 0.00002,
+          budgetEnforced: true,
+        } } }
+      },
+    }
+    const { app } = buildHarness({ getSandbox: async () => sandbox })
+
+    const response = await app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Payment-Signature': buildSpendAuth({ nonce: '9004' }),
+      },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'search' }] }),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.text()
+    const frames = body.split('\n\n').filter(Boolean)
+    const firstData = frames[0]!.split('\n').find((line) => line.startsWith('data: '))
+    const first = JSON.parse(firstData!.slice('data: '.length)) as {
+      choices: Array<{ delta: { role?: string; content?: string } }>
+    }
+
+    expect(first.choices[0]?.delta).toEqual({ role: 'assistant' })
+    expect(frames).toContain(': keep-alive')
+    expect(body).toContain('data: [DONE]')
+  })
+
   it('rejects max_tokens above the configured ceiling before verification', async () => {
     let verifierCalls = 0
     const { app } = buildHarness({
@@ -654,7 +692,14 @@ describe('POST /:slug/chat/completions — auth paths', () => {
       body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
     })
     const reader = response.body!.getReader()
-    await reader.read()
+    const decoder = new TextDecoder()
+    let received = ''
+    while (!received.includes('partial')) {
+      const { value, done } = await reader.read()
+      if (done) break
+      received += decoder.decode(value)
+    }
+    expect(received).toContain('partial')
     await reader.cancel()
     await cleanup
 

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -5,7 +5,7 @@
  * These tests exercise the full payment/auth/rate-limit/filter/stream pipeline.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { Hono } from 'hono'
 import { createAgentGateway } from '../src/middleware'
 import type {
@@ -519,10 +519,16 @@ describe('POST /:slug/chat/completions — auth paths', () => {
     expect(usage[0]?.outputTokens).toBe(2)
   })
 
-  it('emits an assistant role and keepalive for activity-only sandbox work', async () => {
+  it('emits an assistant role and timer keepalive while the sandbox is silent', async () => {
+    vi.useFakeTimers()
+    let release!: () => void
+    const released = new Promise<void>((resolve) => { release = resolve })
+    let sandboxStarted!: () => void
+    const started = new Promise<void>((resolve) => { sandboxStarted = resolve })
     const sandbox: SandboxBox = {
       async *streamPrompt() {
-        yield { type: 'tool.started', data: { tool: { name: 'workspace-search' } } }
+        sandboxStarted()
+        await released
         yield { type: 'sandbox.usage', data: { usage: {
           inputTokens: 1,
           outputTokens: 0,
@@ -534,27 +540,39 @@ describe('POST /:slug/chat/completions — auth paths', () => {
         } } }
       },
     }
-    const { app } = buildHarness({ getSandbox: async () => sandbox })
+    try {
+      const { app } = buildHarness({ getSandbox: async () => sandbox })
+      const response = await app.request('/v1/agents/test-agent/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Payment-Signature': buildSpendAuth({ nonce: '9004' }),
+        },
+        body: JSON.stringify({ messages: [{ role: 'user', content: 'search' }] }),
+      })
+      expect(response.status).toBe(200)
+      const reader = response.body!.getReader()
+      const decoder = new TextDecoder()
+      const roleChunk = await reader.read()
+      expect(decoder.decode(roleChunk.value)).toContain('"role":"assistant"')
+      await started
 
-    const response = await app.request('/v1/agents/test-agent/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Payment-Signature': buildSpendAuth({ nonce: '9004' }),
-      },
-      body: JSON.stringify({ messages: [{ role: 'user', content: 'search' }] }),
-    })
-    expect(response.status).toBe(200)
-    const body = await response.text()
-    const frames = body.split('\n\n').filter(Boolean)
-    const firstData = frames[0]!.split('\n').find((line) => line.startsWith('data: '))
-    const first = JSON.parse(firstData!.slice('data: '.length)) as {
-      choices: Array<{ delta: { role?: string; content?: string } }>
+      const keepaliveRead = reader.read()
+      await vi.advanceTimersByTimeAsync(15_000)
+      expect(decoder.decode((await keepaliveRead).value)).toBe(': keep-alive\n\n')
+
+      release()
+      let body = ''
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        body += decoder.decode(value)
+      }
+      expect(body).toContain('data: [DONE]')
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
     }
-
-    expect(first.choices[0]?.delta).toEqual({ role: 'assistant' })
-    expect(frames).toContain(': keep-alive')
-    expect(body).toContain('data: [DONE]')
   })
 
   it('rejects max_tokens above the configured ceiling before verification', async () => {

--- a/tests/payment-recovery.test.ts
+++ b/tests/payment-recovery.test.ts
@@ -875,7 +875,14 @@ describe('durable OpenAI recovery', () => {
       body: requestBody(),
     })
     const reader = response.body!.getReader()
-    expect(new TextDecoder().decode((await reader.read()).value)).toContain('partial')
+    const decoder = new TextDecoder()
+    let received = ''
+    while (!received.includes('partial')) {
+      const { value, done } = await reader.read()
+      if (done) break
+      received += decoder.decode(value)
+    }
+    expect(received).toContain('partial')
     await reader.cancel()
     for (let attempt = 0; attempt < 20; attempt += 1) await Promise.resolve()
 


### PR DESCRIPTION
## Summary\n\n- Pass the authenticated GatewaySandboxContext through A2A message/send and message/stream; map contextId to threadId, keep taskId as sandbox sessionId, and reject mismatched header/context before sandbox access.\n- Fix silent OpenAI SSE streams: production request req_72f3b4176ab5a8c7d08e3287b3fd0cd3 returned HTTP 200 with 0 bytes for 900002ms while the app thread gained a work_product at +549s. Emit the assistant role frame immediately and a bounded SSE keepalive independent of sandbox event types.\n\n## Proof\n\n- 24 test files, 381 tests passed\n- pnpm run typecheck passed\n- pnpm run build passed\n- git merge-tree --write-tree origin/main HEAD clean\n