### PR TITLE
chore(release): bump agent gateway to 0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "packageManager": "pnpm@10.28.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump the package version after merging PR #16. Typecheck, 381 tests, and build pass.