### PR TITLE
fix(a2a): require durable task storage in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Sandbox adapters should emit a complete `sandbox.usage` receipt.
 Requests with a version 2 operation or generic MPP charge reject missing receipts.
 API-key requests keep the legacy visible-token estimate path.
 recordUsage must atomically upsert by event.requestId; recovery may retry an event after its acknowledgement is lost.
-The default gateway still exposes A2A with an in-memory task store.
+Explicit demo mode exposes A2A with an in-memory task store.
+Production must configure an atomic durable task store; otherwise A2A returns `503` while the OpenAI surface remains available.
 Older custom A2A task stores remain source-compatible at the type boundary.
 The OpenAI surface stays available when such a store is configured, while A2A returns `503` until its owner supplies atomic methods.
 Use an atomic task store for multi-worker production deployments.

--- a/src/a2a/task-store.ts
+++ b/src/a2a/task-store.ts
@@ -1,8 +1,7 @@
 /**
- * Task persistence behind the JSON-RPC dispatcher. Default adapter is in
- * memory with a 1-hour TTL — adequate for tests, scratch, and Workers with
- * a short-lived process. Production deployments wire their own
- * `TaskStore` (D1, postgres, Durable Object) via `GatewayConfig.a2a`.
+ * Task persistence behind the JSON-RPC dispatcher. The in-memory adapter has
+ * a 1-hour TTL and is for explicit demo or test mode. Production deployments
+ * wire their own `TaskStore` (D1, postgres, Durable Object) via `GatewayConfig.a2a`.
  */
 
 import type { Task } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,8 +122,8 @@ export type {
 
 // --- A2A protocol surface (Google Agent-to-Agent) ---
 // Types + task-store adapter. Handlers are wired automatically by
-// createAgentGateway with an in-memory store by default;
-// consumers only import these to BYO a durable TaskStore (D1, postgres, DO)
+// createAgentGateway with an in-memory store only in explicit demo mode;
+// production consumers must BYO an atomic durable TaskStore (D1, postgres, DO)
 // or to declare richer AgentMeta.skills for the Agent Card.
 export { InMemoryTaskStore, type TaskStore } from './a2a/task-store'
 export {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -336,17 +336,21 @@ export function createAgentGateway(inputConfig: CreateAgentGatewayConfig) {
   // Both surfaces share authenticateAndGuard + dispatchSandboxStream +
   // settleAndRecord, so every security and billing guarantee applies uniformly
   // regardless of which protocol the caller used.
-  const taskStore = config.a2a?.taskStore ?? new InMemoryTaskStore()
   const pushStore = config.a2a?.pushStore
   try {
+    // Do not create process-local state for production A2A.
+    if (!config.x402.demoMode && !config.a2a?.taskStore) {
+      throw new Error('A2A production requires an explicitly configured atomic task store')
+    }
+    const taskStore = config.a2a?.taskStore ?? new InMemoryTaskStore()
     const a2a = createA2AHandlers({ config, state, taskStore, pushStore })
     gw.get('/:slug/.well-known/agent.json', a2a.handleAgentCard)
     gw.post('/:slug', a2a.handleJsonRpc)
   } catch (error) {
-    // An older custom store must not take down the OpenAI surface. Keep the
-    // A2A surface unavailable until its owner supplies atomic methods.
+    // A missing or older custom store must not take down the OpenAI surface.
+    // Keep A2A unavailable until its owner supplies atomic methods.
     console.error(
-      '[agent-gateway] A2A is unavailable until its task store is upgraded:',
+      '[agent-gateway] A2A is unavailable until its task store is configured with atomic methods:',
       error instanceof Error ? error.message : String(error),
     )
     const unavailable = (c: import('hono').Context) => c.json(

--- a/src/types.ts
+++ b/src/types.ts
@@ -364,14 +364,16 @@ export interface GatewayConfig {
   observer?: GatewayObserver
 
   /**
-   * A2A protocol configuration. The gateway exposes A2A with an in-memory
-   * task store by default. Set this object to provide durable storage or push:
+   * A2A protocol configuration. Explicit demo mode uses an in-memory task
+   * store by default. Production must provide an atomic durable task store;
+   * without one, A2A returns 503 while the OpenAI surface remains available.
+   * Set this object to provide durable storage or push:
    *   GET  /:slug/.well-known/agent.json   — AgentCard discovery
    *   POST /:slug                          — JSON-RPC 2.0 endpoint
    *     methods: message/send, message/stream, tasks/get, tasks/cancel
    * Auth + rate-limit + injection-filter + authorization all share the
-   * same pipeline as the OpenAI-compat path. `taskStore` defaults to
-   * `InMemoryTaskStore`; swap in D1/postgres/DO for durable deployments.
+   * same pipeline as the OpenAI-compat path. Demo mode defaults to
+   * `InMemoryTaskStore`; production must configure D1/postgres/DO storage.
   */
   a2a?: {
     /**
@@ -389,7 +391,8 @@ export interface GatewayConfig {
       },
     ) => Promise<boolean>
     /**
-     * Where tasks live. Defaults to `InMemoryTaskStore`; swap in
+     * Where tasks live. Required in production and must implement the
+     * atomic methods. Demo mode defaults to `InMemoryTaskStore`; swap in
      * `SqlTaskStore` (D1, postgres, sqlite, libSQL) for durability across
      * gateway restarts.
      */

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -10,6 +10,7 @@ import { Hono } from 'hono'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { A2A_ERROR_CODES } from '../src/a2a/types'
+import { InMemoryTaskStore } from '../src/a2a/task-store'
 import type {
   AgentCard,
   JSONRPCErrorResponse,
@@ -540,6 +541,7 @@ describe('A2A — tasks/get', () => {
   it('fails closed for production task access without an authorization hook', async () => {
     const { app } = buildHarness({
       x402: { operatorAddress, chainId: 3799, verifySigner: async () => true, demoMode: false },
+      a2a: { taskStore: new InMemoryTaskStore() },
     })
     const sendRes = await postJsonRpc(
       app,

--- a/tests/pr11-regressions.test.ts
+++ b/tests/pr11-regressions.test.ts
@@ -1111,8 +1111,9 @@ describe('PR #11 production regressions', () => {
     expect(await store.hasSeen('compatibility')).toBe(true)
   })
 
-  it('does not initialize A2A when an OpenAI-only gateway omits it', () => {
-    expect(() => createAgentGateway({
+  it('keeps A2A unavailable when production omits its task store', async () => {
+    const app = new Hono()
+    app.route('/v1/agents', createAgentGateway({
       resolveAgent: async () => agent,
       getSandbox: async () => sandbox(),
       recordUsage: async () => undefined,
@@ -1122,7 +1123,15 @@ describe('PR #11 production regressions', () => {
         demoMode: false,
         verifySigner: async () => true,
       },
-    })).not.toThrow()
+    }))
+
+    const discovery = await app.request('/v1/agents/pr11/chat/completions')
+    const card = await app.request('/v1/agents/pr11/.well-known/agent.json')
+    const a2a = await app.request('/v1/agents/pr11', { method: 'POST', body: '{}' })
+
+    expect(discovery.status).toBe(200)
+    expect(card.status).toBe(503)
+    expect(a2a.status).toBe(503)
   })
 
   it('keeps the OpenAI surface available when an old A2A store is configured', async () => {


### PR DESCRIPTION
Production A2A must not silently use process-local task state.

Without `a2a.taskStore`, the gateway now keeps the OpenAI surface available and returns HTTP 503 for A2A discovery and JSON-RPC routes. Explicit demo mode retains `InMemoryTaskStore`; supplied production stores still pass the existing atomic-method check.

Root evidence: the gateway defaulted A2A to `InMemoryTaskStore` in production, allowing task state to disappear across workers or restarts.

Proof:
- focused A2A and production-regression tests: 2 passed
- full suite: 381 passed across 24 files
- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`