### PR TITLE
chore(release): publish agent gateway 0.8.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,9 +59,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+          # Do not set registry-url. It creates a placeholder token config
+          # that overrides npm trusted publishing.
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
@@ -75,7 +76,5 @@ jobs:
           if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
             echo "$NAME@$VERSION already on registry; skipping publish"
           else
-            pnpm publish --no-git-checks --access public --provenance
+            npm publish --access public --provenance
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "packageManager": "pnpm@10.28.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release `@tangle-network/agent-gateway@0.8.6` after the production A2A persistence fix merged in PR #18.

The tag publish job now uses npm trusted publishing with Node 24 and `id-token: write`; it does not set `registry-url` or `NODE_AUTH_TOKEN`, which previously forced the invalid npm token path.

Proof:
- `pnpm test -- --reporter=dot`: 381 passed across 24 files
- `pnpm run typecheck`
- `pnpm run build`
- Node v24.18.0 / npm 11.16.0 publish dry-run
- `git diff --check`