### PR TITLE
chore(release): bump agent gateway to 0.8.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "packageManager": "pnpm@10.28.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Publishes the merged A2A D1 affected-row fix as 0.8.7. The patch uses D1 meta.changes instead of indexed billing rows_written. Source and test proof passed before merge: 382/382 tests, typecheck, and build.