### PR TITLE
fix(a2a): keep streams alive during silent work

### DIFF
--- a/src/a2a/message-stream-execution.ts
+++ b/src/a2a/message-stream-execution.ts
@@ -109,6 +109,15 @@ export async function executeMessageStream(
             // The client can cancel between the desiredSize check and enqueue.
           }
         }
+        const sendKeepalive = () => {
+          if (ctrl.desiredSize === null) return
+          try {
+            ctrl.enqueue(encoder.encode(': keep-alive\n\n'))
+          } catch {
+            // The client can cancel between the desiredSize check and enqueue.
+          }
+        }
+        const keepaliveTimer = setInterval(sendKeepalive, 15_000)
 
         let inputRequiredPrompt: string | undefined
         let inputRequiredSeen = false
@@ -361,6 +370,7 @@ export async function executeMessageStream(
             )
           }
         } finally {
+          clearInterval(keepaliveTimer)
           detachRequestAbort()
           deps.cancels.clear(task.id)
           try {

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { Hono } from 'hono'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { A2A_ERROR_CODES } from '../src/a2a/types'
 import { InMemoryTaskStore } from '../src/a2a/task-store'
@@ -430,6 +430,66 @@ describe('A2A — message/stream', () => {
     // Settlement + usage fire after stream completes.
     expect(harness.usage).toHaveLength(1)
     expect(harness.settlements).toHaveLength(1)
+  })
+
+  it('emits a timer keepalive while the sandbox is silent and clears it on completion', async () => {
+    vi.useFakeTimers()
+    let release!: () => void
+    const released = new Promise<void>((resolve) => { release = resolve })
+    let sandboxStarted!: () => void
+    const started = new Promise<void>((resolve) => { sandboxStarted = resolve })
+    const sandbox: SandboxBox = {
+      async *streamPrompt() {
+        sandboxStarted()
+        await released
+        yield {
+          type: 'sandbox.usage',
+          data: {
+            usage: {
+              inputTokens: 1,
+              outputTokens: 0,
+              reasoningTokens: 0,
+              toolTokens: 0,
+              toolCallCount: 1,
+              providerCostUsd: 0.00002,
+              budgetEnforced: true,
+            },
+          },
+        }
+      },
+    }
+
+    try {
+      const harness = buildHarness({ getSandbox: async () => sandbox })
+      const response = await postJsonRpc(
+        harness.app,
+        'test-agent',
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'message/stream',
+          params: { message: textMessage('search') },
+        },
+        apiKeyHeader(),
+      )
+      expect(response.status).toBe(200)
+      const reader = response.body!.getReader()
+      const decoder = new TextDecoder()
+      expect(decoder.decode((await reader.read()).value)).toContain('"state":"working"')
+      await started
+
+      const keepaliveRead = reader.read()
+      await vi.advanceTimersByTimeAsync(15_000)
+      expect(decoder.decode((await keepaliveRead).value)).toBe(': keep-alive\n\n')
+
+      release()
+      while (!(await reader.read()).done) {
+        // Drain the response so the stream cleanup runs.
+      }
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 


### PR DESCRIPTION
## Root cause

The OpenAI-compatible SSE path emits `: keep-alive` every 15 seconds, but `message/stream` emitted nothing during silent tool or activity periods.

A2A clients and intermediaries could therefore close a valid long-running stream before the agent produced visible text.

## Fix

Add one 15-second comment heartbeat to the A2A `ReadableStream`.

The interval checks stream backpressure, catches client-close races, and is cleared in the stream's `finally` block.

## Proof

- `pnpm vitest run tests/a2a.test.ts -t "timer keepalive"` — 1/1 passed
- `pnpm vitest run tests/a2a.test.ts` — 22/22 passed
- `pnpm test` — 383/383 passed across 24 files
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `git diff --check` — passed
