### PR TITLE
chore(release): bump agent gateway to 0.8.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "packageManager": "pnpm@10.28.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Publishes the merged A2A stream heartbeat fix as 0.8.8. The release commit contains only the version bump; PR #22 already passed 383/383 tests, typecheck, and build.