### PR TITLE
fix(gateway): fail closed on terminal sandbox errors

### DIFF
--- a/.agent/release-progress.md
+++ b/.agent/release-progress.md
@@ -1,0 +1,30 @@
+# Release Progress
+
+## Target
+- Environment: npm registry
+- Live URL: https://www.npmjs.com/package/@tangle-network/agent-gateway
+- Live service/process: npm package `@tangle-network/agent-gateway`
+- Artifact path: tag-triggered GitHub Actions publish workflow
+- Rollback artifact/path: retain v0.8.8; publish a follow-up patch if needed
+- Credential files: GitHub trusted publishing and npm provenance workflow
+
+## Local State
+- Branch: fix/gateway-structured-failure
+- Commit: ce3b7ac (v0.8.8)
+- Dirty files: clean at start
+- Gates planned: focused failure tests, full typecheck/test/build, PR review, npm version proof
+
+## Remote State
+- Host/provider: GitHub Actions + npm trusted publishing
+- Current live artifact: @tangle-network/agent-gateway@0.8.8
+- Current service status: package registry state to verify before release
+- Last smoke result: pending
+
+## Decision
+- Build path: tag-triggered GitHub Actions publish
+- Reason: repository workflow owns verification, provenance, and npm publication
+- Expected duration: minutes after merge and tag push
+- Fallback/rollback: retain v0.8.8 and diagnose failed workflow before retrying
+
+## Timeline
+- 2026-09-01: confirmed branch starts at origin/main v0.8.8; implementation pending

--- a/src/dispatch-sandbox.ts
+++ b/src/dispatch-sandbox.ts
@@ -27,6 +27,29 @@ export function buildGatewaySandboxContext(
   }
 }
 
+/** Terminal failure reported by the sandbox event protocol. */
+export class SandboxStreamError extends Error {
+  readonly eventType: string
+  readonly code?: string
+  readonly details?: Record<string, unknown>
+
+  constructor(event: SandboxStreamEvent) {
+    const rawMessage = event.data?.message
+    const message = typeof rawMessage === 'string' && rawMessage.trim().length > 0
+      ? rawMessage.trim()
+      : 'Sandbox stream failed'
+    super(message)
+    this.name = 'SandboxStreamError'
+    this.eventType = event.type ?? 'unknown'
+    if (typeof event.data?.code === 'string' && event.data.code.length > 0) {
+      this.code = event.data.code
+    }
+    if (event.data?.details && typeof event.data.details === 'object' && !Array.isArray(event.data.details)) {
+      this.details = event.data.details
+    }
+  }
+}
+
 export async function* dispatchSandboxStream(
   agent: AgentMeta,
   userMessage: string,
@@ -157,6 +180,9 @@ export async function* dispatchSandboxStreamRich(
       }
       if (next.done) break
       const event = next.value
+      if (event.type === 'error' || event.type === 'session.run.failed') {
+        throw new SandboxStreamError(event)
+      }
       if (event.data?.usage) usageParts = mergeUsage(usageParts, event.data.usage)
       if (event.data?.reasoning?.tokens !== undefined) {
         observedReasoningTokens += nonNegativeSafeInteger(event.data.reasoning.tokens, 'reasoning tokens')

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -34,6 +34,7 @@ export {
   buildGatewaySandboxContext,
   dispatchSandboxStream,
   dispatchSandboxStreamRich,
+  SandboxStreamError,
 } from './dispatch-sandbox'
 
 export { settleAndRecord } from './dispatch-settlement'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { createAgentGateway } from './middleware'
-export { reclaimPayment } from './dispatch'
+export { reclaimPayment, SandboxStreamError } from './dispatch'
 export {
   recoverPayment,
   recoverPayments,

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,10 @@ export interface SandboxStreamEvent {
     part?: { type?: string; text?: string }
     delta?: string
     finalText?: string
+    /** Structured failure fields emitted by terminal `error` events. */
+    code?: string
+    message?: string
+    details?: Record<string, unknown>
     /**
      * Optional sandbox-side signal that the agent has paused and is waiting
      * for additional input from the caller. The A2A gateway translates this

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -148,6 +148,15 @@ function apiKeyHeader(): Record<string, string> {
   return { Authorization: 'Bearer sk_agent_test_key_1' }
 }
 
+const structuredSandboxFailure: SandboxStreamEvent = {
+  type: 'error',
+  data: {
+    code: 'sandbox.provisioning_failed',
+    message: 'Unable to connect',
+    details: { supportDetails: 'sandbox unavailable' },
+  },
+}
+
 function textMessage(text: string, taskId?: string, contextId?: string) {
   return {
     kind: 'message' as const,
@@ -387,6 +396,77 @@ describe('A2A — message/send', () => {
     expect(res.status).toBe(400)
     const body = (await res.json()) as { error: { type: string } }
     expect(body.error.type).toBe('content_policy_violation')
+  })
+
+  it.each([
+    structuredSandboxFailure,
+    {
+      type: 'session.run.failed',
+      data: structuredSandboxFailure.data,
+    },
+  ] as const)('fails the OpenAI stream on terminal sandbox event %s', async (failureEvent) => {
+    const harness = buildHarness({
+      getSandbox: async () => ({
+        async *streamPrompt() {
+          yield failureEvent
+          yield { type: 'session.run.completed', data: {} }
+        },
+      }),
+    })
+
+    const response = await harness.app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...apiKeyHeader() },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'connect' }], stream: true }),
+    })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('"type":"server_error"')
+    expect(body).toContain('Unable to connect')
+    expect(body).not.toContain('[DONE]')
+    expect(harness.usage).toHaveLength(0)
+    expect(harness.settlements).toHaveLength(0)
+  })
+
+  it('persists an A2A task as failed for the structured sandbox error shape', async () => {
+    const harness = buildHarness({
+      getSandbox: async () => ({
+        async *streamPrompt() {
+          yield structuredSandboxFailure
+          yield { type: 'session.run.completed', data: {} }
+        },
+      }),
+    })
+
+    const response = await postJsonRpc(
+      harness.app,
+      'test-agent',
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'message/send',
+        params: { message: textMessage('connect', 'structured-failure-task', 'structured-failure-context') },
+      },
+      apiKeyHeader(),
+    )
+    const body = (await response.json()) as JSONRPCErrorResponse
+
+    expect(response.status).toBe(200)
+    expect(body.error.code).toBe(A2A_ERROR_CODES.INTERNAL_ERROR)
+    expect(body.error.message).toBe('Unable to connect')
+
+    const taskResponse = await postJsonRpc(
+      harness.app,
+      'test-agent',
+      { jsonrpc: '2.0', id: 2, method: 'tasks/get', params: { id: 'structured-failure-task' } },
+      apiKeyHeader(),
+    )
+    const task = (await taskResponse.json() as JSONRPCSuccessResponse<Task>).result
+    expect(task.status.state).toBe('failed')
+    expect(task.artifacts).toBeUndefined()
+    expect(harness.usage).toHaveLength(0)
+    expect(harness.settlements).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
## Summary
- Treat sandbox `error` and `session.run.failed` events as terminal failures in the shared dispatcher.
- Preserve the structured event code and details on the gateway error.
- Prove OpenAI streams emit no success marker or usage, and A2A persists a failed task without an empty artifact.

## Verification
- `pnpm exec vitest run tests/a2a.test.ts` (25/25)
- `pnpm run typecheck`
- `pnpm run test` (386/386 across 24 files)
- `pnpm run build`
- `npm view @tangle-network/agent-gateway version` (0.8.8 before release)
