### PR TITLE
fix(a2a): enforce server-owned task ids

### DIFF
--- a/docs/a2a-long-horizon.md
+++ b/docs/a2a-long-horizon.md
@@ -394,7 +394,8 @@ Sandboxes that never emit input-required see identical behavior to before.
 //                  history: [ msg_1, msg_2 ], artifacts: [...] }
 ```
 
-A follow-up against a task in any state other than `input-required` is rejected with `INVALID_PARAMS` ("only 'input-required' tasks accept follow-up messages"). The gateway never silently re-runs or merges into a terminal task.
+Initial messages omit `taskId`; the gateway assigns the task ID. A supplied unknown task ID returns `TASK_NOT_FOUND` for both messaging methods.
+A follow-up against a task in any state other than `input-required` is rejected with `UNSUPPORTED_OPERATION` ("only 'input-required' tasks accept follow-up messages"). The gateway never silently re-runs or merges into a terminal task.
 
 ## Putting it all together — long-horizon agent loop
 

--- a/src/a2a/handler.ts
+++ b/src/a2a/handler.ts
@@ -320,18 +320,21 @@ async function guardMessageRequest(
   let knownTaskContextId: string | undefined
   if (typeof params.message.taskId === 'string') {
     const storedForQuote = await deps.taskStore.get(params.message.taskId)
-    if (storedForQuote) {
-      const accessError = await authorizeTaskAccess(c, req, storedForQuote, deps)
-      if (accessError) return accessError
-      const quotedTask = await recoverTaskIfNeeded(storedForQuote, deps, slug)
-      if (quotedTask.status.state === 'input-required') {
-        billingMessages = [
-          ...taskHistoryAsChatMessages(quotedTask),
-          { role: 'user', content: extracted.text },
-        ]
-      }
-      knownTaskContextId = quotedTask.contextId
+    if (!storedForQuote) {
+      return c.json(
+        fail(req.id, A2A_ERROR_CODES.TASK_NOT_FOUND, `task '${params.message.taskId}' not found`),
+      )
     }
+    const accessError = await authorizeTaskAccess(c, req, storedForQuote, deps)
+    if (accessError) return accessError
+    const quotedTask = await recoverTaskIfNeeded(storedForQuote, deps, slug)
+    if (quotedTask.status.state === 'input-required') {
+      billingMessages = [
+        ...taskHistoryAsChatMessages(quotedTask),
+        { role: 'user', content: extracted.text },
+      ]
+    }
+    knownTaskContextId = quotedTask.contextId
   }
 
   const messageContextId = typeof params.message.contextId === 'string'
@@ -360,48 +363,49 @@ async function guardMessageRequest(
   // currently in `input-required`, append the new message and reserve it as
   // `submitted`. The handler transitions it to `working` only after payment
   // succeeds, so cancellation during payment cannot start sandbox work.
-  // Any other taskId (unknown OR pointing at a terminal/working
-  // task) means the caller is starting a fresh task and we mint a new id.
+  // A supplied taskId must identify an existing task. Only `input-required`
+  // tasks accept a follow-up message.
   if (typeof params.message.taskId === 'string') {
     const storedExisting = await deps.taskStore.get(params.message.taskId)
-    if (storedExisting) {
-      const accessError = await authorizeTaskAccess(c, req, storedExisting, deps)
-      if (accessError) return accessError
-      const existing = await recoverTaskIfNeeded(storedExisting, deps, slug)
-      if (existing.status.state !== 'input-required') {
-        return c.json(
-          fail(
-            req.id,
-            A2A_ERROR_CODES.INVALID_PARAMS,
-            `task '${existing.id}' is in state '${existing.status.state}'; only 'input-required' tasks accept follow-up messages`,
-          ),
-        )
-      }
-      const appendedMessage: Message = {
-        ...params.message,
-        taskId: existing.id,
-        contextId: existing.contextId,
-      }
-      const continued: Task = {
-        ...existing,
-        status: { state: 'submitted', timestamp: nowIso() },
-        history: [...(existing.history ?? []), appendedMessage],
-        metadata: withTaskSubmission(existing.metadata, authz),
-      }
-      if (!await compareAndSetTask(deps.taskStore, existing, continued)) {
-        return c.json(
-          fail(req.id, A2A_ERROR_CODES.INVALID_PARAMS, `task '${existing.id}' changed before continuation`),
-        )
-      }
-      const claimedTask = await claimTaskPayment(c, req, continued, authz, deps, existing)
-      if (claimedTask instanceof Response) return claimedTask
-      return { authz, task: claimedTask }
+    if (!storedExisting) {
+      return c.json(
+        fail(req.id, A2A_ERROR_CODES.TASK_NOT_FOUND, `task '${params.message.taskId}' not found`),
+      )
     }
-    // Unknown taskId in params: fall through and mint a fresh task with that
-    // exact id so callers that pre-allocate ids (idempotency) get them.
+    const accessError = await authorizeTaskAccess(c, req, storedExisting, deps)
+    if (accessError) return accessError
+    const existing = await recoverTaskIfNeeded(storedExisting, deps, slug)
+    if (existing.status.state !== 'input-required') {
+      return c.json(
+        fail(
+          req.id,
+          A2A_ERROR_CODES.UNSUPPORTED_OPERATION,
+          `task '${existing.id}' is in state '${existing.status.state}'; only 'input-required' tasks accept follow-up messages`,
+        ),
+      )
+    }
+    const appendedMessage: Message = {
+      ...params.message,
+      taskId: existing.id,
+      contextId: existing.contextId,
+    }
+    const continued: Task = {
+      ...existing,
+      status: { state: 'submitted', timestamp: nowIso() },
+      history: [...(existing.history ?? []), appendedMessage],
+      metadata: withTaskSubmission(existing.metadata, authz),
+    }
+    if (!await compareAndSetTask(deps.taskStore, existing, continued)) {
+      return c.json(
+        fail(req.id, A2A_ERROR_CODES.INVALID_PARAMS, `task '${existing.id}' changed before continuation`),
+      )
+    }
+    const claimedTask = await claimTaskPayment(c, req, continued, authz, deps, existing)
+    if (claimedTask instanceof Response) return claimedTask
+    return { authz, task: claimedTask }
   }
 
-  const taskId = params.message.taskId ?? `task_${cryptoRandomId()}`
+  const taskId = `task_${cryptoRandomId()}`
   const contextId = knownTaskContextId ?? (
     deps.config.conversationMode === 'thread'
       ? authz.threadId ?? `ctx_${cryptoRandomId()}`

--- a/tests/a2a-atomicity.test.ts
+++ b/tests/a2a-atomicity.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { InMemoryTaskStore, type TaskStore } from '../src/a2a/task-store'
 import { createAgentGateway } from '../src/middleware'
@@ -52,7 +52,7 @@ function paymentHeader(nonce: string): string {
   })
 }
 
-function requestBody(taskId: string, text: string) {
+function requestBody(text: string) {
   return {
     jsonrpc: '2.0',
     id: text,
@@ -61,7 +61,6 @@ function requestBody(taskId: string, text: string) {
       message: {
         kind: 'message',
         role: 'user',
-        taskId,
         contextId: 'ctx-atomicity',
         messageId: `message-${text}`,
         parts: [{ kind: 'text', text }],
@@ -187,31 +186,36 @@ describe('A2A task atomicity and restart recovery', () => {
     first.route('/v1/agents', createAgentGateway(atomicityConfig(taskStore, counters, true)))
     second.route('/v1/agents', createAgentGateway(atomicityConfig(taskStore, counters, true)))
 
-    const request = (app: Hono, nonce: string, text: string) => app.request(
-      `/v1/agents/${agent.slug}`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Payment-Signature': paymentHeader(nonce),
+    const randomUUID = vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue('a'.repeat(32))
+    try {
+      const request = (app: Hono, nonce: string, text: string) => app.request(
+        `/v1/agents/${agent.slug}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Payment-Signature': paymentHeader(nonce),
+          },
+          body: JSON.stringify(requestBody(text)),
         },
-        body: JSON.stringify(requestBody('task-two-workers', text)),
-      },
-    )
+      )
 
-    const [firstResponse, secondResponse] = await Promise.all([
-      request(first, '101', 'one'),
-      request(second, '102', 'two'),
-    ])
-    const bodies = await Promise.all([
-      firstResponse.json(),
-      secondResponse.json(),
-    ]) as Array<{ result?: { status?: { state?: string } }; error?: { code?: number } }>
-    expect(bodies.filter((body) => body.result?.status?.state === 'completed')).toHaveLength(1)
-    expect(bodies.filter((body) => body.error?.code === -32602)).toHaveLength(1)
-    expect(counters.runs).toBe(1)
-    expect(counters.records).toBe(1)
-    expect(counters.settlements).toBe(1)
+      const [firstResponse, secondResponse] = await Promise.all([
+        request(first, '101', 'one'),
+        request(second, '102', 'two'),
+      ])
+      const bodies = await Promise.all([
+        firstResponse.json(),
+        secondResponse.json(),
+      ]) as Array<{ result?: { status?: { state?: string } }; error?: { code?: number } }>
+      expect(bodies.filter((body) => body.result?.status?.state === 'completed')).toHaveLength(1)
+      expect(bodies.filter((body) => body.error?.code === -32602)).toHaveLength(1)
+      expect(counters.runs).toBe(1)
+      expect(counters.records).toBe(1)
+      expect(counters.settlements).toBe(1)
+    } finally {
+      randomUUID.mockRestore()
+    }
   })
 
   it('replays a crashed finalization after restart and clears the lease marker', async () => {

--- a/tests/a2a-lifecycle.test.ts
+++ b/tests/a2a-lifecycle.test.ts
@@ -6,6 +6,7 @@ import { createAgentGateway } from '../src/middleware'
 import { MemoryNonceStore } from '../src/nonce-store'
 import type { AgentMeta, GatewayConfig, SandboxBox } from '../src/types'
 import type { Task } from '../src/a2a/types'
+import { ServerAssignedTaskStore } from './server-assigned-task-store'
 
 const operatorAddress = '0x1111111111111111111111111111111111111111'
 const commitment = `0x${'ef'.repeat(32)}`
@@ -46,21 +47,20 @@ function paymentHeader(nonce: string): string {
   })
 }
 
-function message(taskId: string, text = 'hello') {
+function message(taskId: string | undefined, text = 'hello') {
   return {
     kind: 'message',
     role: 'user',
-    taskId,
-    contextId: `context-${taskId}`,
-    messageId: `message-${taskId}-${text}`,
+    ...(taskId ? { taskId, contextId: `context-${taskId}` } : {}),
+    messageId: `message-${taskId ?? 'new'}-${text}`,
     parts: [{ kind: 'text', text }],
   }
 }
 
-function body(method: string, taskId: string, text = 'hello') {
+function body(method: string, taskId?: string, text = 'hello') {
   return {
     jsonrpc: '2.0',
-    id: `${method}-${taskId}`,
+    id: `${method}-${taskId ?? 'new'}`,
     method,
     params: method.startsWith('tasks/') ? { id: taskId } : { message: message(taskId, text) },
   }
@@ -97,7 +97,10 @@ async function post(app: Hono, slug: string, requestBody: unknown, headers: Reco
 
 describe('A2A lifecycle recovery and ownership', () => {
   it('retries legacy settlement from the durable task record after a crash', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-legacy-recovery',
+    )
     let settlementCalls = 0
     let usageCalls = 0
     const app = new Hono()
@@ -122,7 +125,7 @@ describe('A2A lifecycle recovery and ownership', () => {
     const first = await post(
       app,
       agentA.slug,
-      body('message/send', 'task-legacy-recovery'),
+      body('message/send'),
       { 'X-Payment-Signature': paymentHeader('901') },
     )
     const firstBody = await first.json() as { error?: { code?: number } }
@@ -213,7 +216,10 @@ describe('A2A lifecycle recovery and ownership', () => {
       }
     }
 
-    const taskStore = new InterleavingFailureStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InterleavingFailureStore(),
+      'task-stale-failure',
+    )
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway(gatewayConfig(taskStore, {
       getSandbox: async () => ({
@@ -226,7 +232,7 @@ describe('A2A lifecycle recovery and ownership', () => {
     const response = await post(
       app,
       agentA.slug,
-      body('message/send', 'task-stale-failure'),
+      body('message/send'),
       { 'X-Payment-Signature': paymentHeader('902') },
     )
     expect((await response.json() as { error?: unknown }).error).toBeDefined()
@@ -237,7 +243,10 @@ describe('A2A lifecycle recovery and ownership', () => {
   })
 
   it('rejects task access and continuation through a different originating agent', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-origin-bound',
+    )
     let resolvedOriginAgent = agentA
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway({
@@ -252,7 +261,7 @@ describe('A2A lifecycle recovery and ownership', () => {
     const created = await post(
       app,
       agentA.slug,
-      body('message/send', 'task-origin-bound'),
+      body('message/send'),
       { 'X-Payment-Signature': paymentHeader('903') },
     )
     expect((await created.json() as { result?: Task }).result?.status.state).toBe('completed')
@@ -304,14 +313,17 @@ describe('A2A lifecycle recovery and ownership', () => {
       }
     }
 
-    const taskStore = new CrashAfterCreateStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new CrashAfterCreateStore(),
+      'task-created-before-claim',
+    )
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway(gatewayConfig(taskStore)))
 
     await post(
       app,
       agentA.slug,
-      body('message/send', 'task-created-before-claim'),
+      body('message/send'),
       { 'X-Payment-Signature': paymentHeader('904') },
     )
 
@@ -375,7 +387,7 @@ describe('A2A client disconnect cancellation', () => {
     const response = await post(
       app,
       agentA.slug,
-      body('message/stream', 'task-reader-disconnect'),
+      body('message/stream'),
       { 'X-Payment-Signature': paymentHeader('905') },
     )
     const reader = response.body!.getReader()
@@ -395,7 +407,7 @@ describe('A2A client disconnect cancellation', () => {
         'Content-Type': 'application/json',
         'X-Payment-Signature': paymentHeader('906'),
       },
-      body: JSON.stringify(body('message/stream', 'task-request-disconnect')),
+      body: JSON.stringify(body('message/stream')),
       signal: requestAbort.signal,
     })
     const response = await app.fetch(request)

--- a/tests/a2a-long-horizon.test.ts
+++ b/tests/a2a-long-horizon.test.ts
@@ -478,7 +478,7 @@ describe('A2A — push delivery on terminal state', () => {
       { chunks: ['part '], pause: { prompt: 'continue?' } },
     ])
     const { app, fetchMock, pushStore } = buildHarness({ sandbox })
-    // Register push for a task id we'll fabricate via an explicit message.taskId.
+    // Register push for an unrelated task to prove input-required is not terminal.
     const taskId = 'task_explicit_1'
     // First message must create the task; push registration requires task to exist.
     // So: create with a small no-pause sequence first, then run pause sequence
@@ -501,10 +501,9 @@ describe('A2A — push delivery on terminal state', () => {
   })
 
   it('webhook delivery: headers + body match the documented contract (unit-level)', async () => {
-    // The realistic flow: client pre-allocates taskId, registers push,
-    // THEN issues message/send (which uses that taskId). Push fires at
-    // terminal. We simulate this by registering on a separate task that we
-    // know about, then driving the same id through message/send.
+    // The realistic flow creates a task first, then registers push for its
+    // server-assigned taskId. We test delivery directly because this fixture
+    // does not need another gateway execution.
 
     // Concrete test: we cannot pre-register because set requires task to
     // exist. Instead, this test verifies the delivery mechanic by manually
@@ -710,7 +709,7 @@ describe('A2A — input-required + multi-turn via taskId', () => {
       apiKeyHeader(),
     )
     const body = (await followup.json()) as JSONRPCErrorResponse
-    expect(body.error.code).toBe(A2A_ERROR_CODES.INVALID_PARAMS)
+    expect(body.error.code).toBe(A2A_ERROR_CODES.UNSUPPORTED_OPERATION)
     expect(body.error.message).toContain('input-required')
   })
 })

--- a/tests/a2a-payment-races.test.ts
+++ b/tests/a2a-payment-races.test.ts
@@ -9,6 +9,7 @@ import { MemoryPaymentOperations, type PaymentOperation } from '../src/payment-o
 import { MemoryPaymentRecoveryStore } from '../src/payment-recovery'
 import { recoverPayment } from '../src/payment-recovery-worker'
 import type { AgentMeta, GatewayConfig, SandboxBox } from '../src/types'
+import { ServerAssignedTaskStore } from './server-assigned-task-store'
 
 const operatorAddress = '0x1111111111111111111111111111111111111111'
 const commitment = `0x${'ab'.repeat(32)}`
@@ -91,11 +92,11 @@ class A2AChargeLifecycle implements MppChargeLifecycle {
   }
 }
 
-function message(text: string, taskId: string) {
+function message(text: string, taskId?: string) {
   return {
     kind: 'message',
     role: 'user',
-    taskId,
+    ...(taskId ? { taskId } : {}),
     contextId: 'ctx-race',
     messageId: `message-${text}`,
     parts: [{ kind: 'text', text }],
@@ -265,7 +266,10 @@ describe('A2A payment ownership races', () => {
   })
 
   it('releases payment when cancellation interrupts execution before sandbox start', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-before-sandbox',
+    )
     let executionStarted!: () => void
     const executionReady = new Promise<void>((resolve) => { executionStarted = resolve })
     let releaseExecution!: () => void
@@ -313,7 +317,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: message('run', 'task-before-sandbox') },
+        params: { message: message('run') },
       }),
     })
     await executionReady
@@ -396,7 +400,10 @@ describe('A2A payment ownership races', () => {
   })
 
   it('returns a canceled synchronous task without losing payment ownership', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-sync-cancel',
+    )
     const operations = new MemoryPaymentOperations()
     let outputSeen!: () => void
     const outputReady = new Promise<void>((resolve) => { outputSeen = resolve })
@@ -432,7 +439,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: message('run', 'task-sync-cancel') },
+        params: { message: message('run') },
       }),
     })
     await outputReady
@@ -464,7 +471,7 @@ describe('A2A payment ownership races', () => {
     const finalizationReady = new Promise<void>((resolve) => { finalizationSeen = resolve })
     let releaseFinalization!: () => void
     const finalizationReleased = new Promise<void>((resolve) => { releaseFinalization = resolve })
-    const taskStore: TaskStore = {
+    const innerTaskStore: TaskStore = {
       get: (id) => innerStore.get(id),
       put: (task) => innerStore.put(task),
       createIfAbsent: (task) => innerStore.createIfAbsent(task),
@@ -479,6 +486,7 @@ describe('A2A payment ownership races', () => {
       compareAndSetExecution: (expected, next, requestId, now) =>
         innerStore.compareAndSetExecution(expected, next, requestId, now),
     }
+    const taskStore = new ServerAssignedTaskStore(innerTaskStore, 'task-finalization-cancel')
     let settlements = 0
     const operations = new MemoryPaymentOperations({
       onSettle: async () => { settlements += 1 },
@@ -512,7 +520,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: message('run', 'task-finalization-cancel') },
+        params: { message: message('run') },
       }),
     })
     await finalizationReady
@@ -545,7 +553,7 @@ describe('A2A payment ownership races', () => {
     let releaseCancellation!: () => void
     const cancellationReleased = new Promise<void>((resolve) => { releaseCancellation = resolve })
     let cancellationBlocked = false
-    const taskStore: TaskStore = {
+    const innerTaskStore: TaskStore = {
       get: (id) => innerStore.get(id),
       put: (task) => innerStore.put(task),
       createIfAbsent: (task) => innerStore.createIfAbsent(task),
@@ -562,6 +570,7 @@ describe('A2A payment ownership races', () => {
       compareAndSetExecution: (expected, next, requestId, now) =>
         innerStore.compareAndSetExecution(expected, next, requestId, now),
     }
+    const taskStore = new ServerAssignedTaskStore(innerTaskStore, 'task-stream-finalization-cancel')
     let sandboxDrained!: () => void
     const sandboxReady = new Promise<void>((resolve) => { sandboxDrained = resolve })
     let releaseSandbox!: () => void
@@ -601,7 +610,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/stream',
-        params: { message: message('run', 'task-stream-finalization-cancel') },
+        params: { message: message('run') },
       }),
     })
     const reader = stream.body!.getReader()
@@ -636,7 +645,10 @@ describe('A2A payment ownership races', () => {
   })
 
   it('returns after cancel when a sandbox stops emitting events', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-silent-cancel',
+    )
     const operations = new MemoryPaymentOperations()
     let outputSeen!: () => void
     const outputReady = new Promise<void>((resolve) => { outputSeen = resolve })
@@ -672,7 +684,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: message('run', 'task-silent-cancel') },
+        params: { message: message('run') },
       }),
     })
     await outputReady
@@ -700,7 +712,10 @@ describe('A2A payment ownership races', () => {
   })
 
   it('retains ownership when cancellation follows delivered output without a receipt', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-cancel',
+    )
     const operations = new MemoryPaymentOperations()
     let outputSeen!: () => void
     const outputReady = new Promise<void>((resolve) => { outputSeen = resolve })
@@ -739,7 +754,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/stream',
-        params: { message: message('run', 'task-cancel') },
+        params: { message: message('run') },
       }),
     })
     const stream = await streamPromise
@@ -774,7 +789,7 @@ describe('A2A payment ownership races', () => {
     let releaseFinalization!: () => void
     const finalizationReleased = new Promise<void>((resolve) => { releaseFinalization = resolve })
     let firstFinalization = true
-    const taskStore: TaskStore = {
+    const innerTaskStore: TaskStore = {
       get: (id) => innerStore.get(id),
       put: (task) => innerStore.put(task),
       createIfAbsent: (task) => innerStore.createIfAbsent(task),
@@ -790,6 +805,10 @@ describe('A2A payment ownership races', () => {
       compareAndSetExecution: (expected, next, requestId, now) =>
         innerStore.compareAndSetExecution(expected, next, requestId, now),
     }
+    const taskStore = new ServerAssignedTaskStore(
+      innerTaskStore,
+      'task-canceled-settlement-recovery',
+    )
     let settlementAttempts = 0
     let recoveryAttempts = 0
     let records = 0
@@ -829,7 +848,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: message('run', 'task-canceled-settlement-recovery') },
+        params: { message: message('run') },
       }),
     })
     await finalizationReady
@@ -894,7 +913,10 @@ describe('A2A payment ownership races', () => {
   })
 
   it('persists and recovers an ambiguous release acknowledgement', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-release-recovery',
+    )
     const recoveryStore = new MemoryPaymentRecoveryStore()
     let executionStarted!: () => void
     const executionReady = new Promise<void>((resolve) => { executionStarted = resolve })
@@ -952,7 +974,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: message('run', 'task-release-recovery') },
+        params: { message: message('run') },
       }),
     })
     await executionReady
@@ -1005,7 +1027,10 @@ describe('A2A payment ownership races', () => {
   })
 
   it('recovers an ambiguous release after shared nonce ownership fails', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-nonce-release-recovery',
+    )
     const recoveryStore = new MemoryPaymentRecoveryStore()
     const nonceStore = {
       hasSeen: async () => false,
@@ -1060,7 +1085,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: message('run', 'task-nonce-release-recovery') },
+        params: { message: message('run') },
       }),
     })
     const body = await response.json() as { error?: { code?: number } }
@@ -1098,7 +1123,10 @@ describe('A2A payment ownership races', () => {
   })
 
   it('records usage once when an inserted acknowledgement is lost', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-usage-recovery',
+    )
     const operations = new MemoryPaymentOperations({ onReclaim: async () => undefined })
     const usageRequestIds = new Set<string>()
     let recordCalls = 0
@@ -1143,7 +1171,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: message('run', 'task-usage-recovery') },
+        params: { message: message('run') },
       }),
     })
     const body = await send.json() as { error?: { code?: number } }
@@ -1192,7 +1220,10 @@ describe('A2A payment ownership races', () => {
   })
 
   it('cancels during generic MPP confirmation without executing or stranding the charge', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-stripe-confirm-cancel',
+    )
     const lifecycle = new A2AChargeLifecycle()
     let confirmationStarted!: () => void
     const confirmationReady = new Promise<void>((resolve) => { confirmationStarted = resolve })
@@ -1234,7 +1265,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: message('run', 'task-stripe-confirm-cancel') },
+        params: { message: message('run') },
       }),
     })
     await confirmationReady
@@ -1293,7 +1324,7 @@ describe('A2A payment ownership races', () => {
     }
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway(config))
-    const request = (method: 'message/send' | 'message/stream', taskId: string, token: string) =>
+    const request = (method: 'message/send' | 'message/stream', requestId: string, token: string) =>
       app.request('/v1/agents/a2a-races', {
         method: 'POST',
         headers: {
@@ -1302,15 +1333,15 @@ describe('A2A payment ownership races', () => {
         },
         body: JSON.stringify({
           jsonrpc: '2.0',
-          id: taskId,
+          id: requestId,
           method,
-          params: { message: message('run', taskId) },
+          params: { message: message('run') },
         }),
       })
 
-    const sent = await request('message/send', 'task-stripe-send-receipt', 'spt_send_receipt')
+    const sent = await request('message/send', 'send-receipt', 'spt_send_receipt')
     await sent.text()
-    const streamed = await request('message/stream', 'task-stripe-stream-receipt', 'spt_stream_receipt')
+    const streamed = await request('message/stream', 'stream-receipt', 'spt_stream_receipt')
     await streamed.text()
 
     expect(sent.status).toBe(200)
@@ -1323,7 +1354,10 @@ describe('A2A payment ownership races', () => {
   })
 
   it('recovers generic MPP usage acknowledgement loss from the durable task receipt', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-stripe-usage-recovery',
+    )
     const recoveryStore = new MemoryPaymentRecoveryStore()
     const lifecycle = new A2AChargeLifecycle()
     const requestIds = new Set<string>()
@@ -1370,7 +1404,7 @@ describe('A2A payment ownership races', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: message('run', 'task-stripe-usage-recovery') },
+        params: { message: message('run') },
       }),
     })
     const failed = await sent.json() as { error?: { code?: number } }

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -531,9 +531,10 @@ describe('A2A — authenticated sandbox context', () => {
     })
 
     const requests = [
-      { id: 1, method: 'message/send' as const, text: 'send', taskId: 'send-task', contextId: 'send-context' },
-      { id: 2, method: 'message/stream' as const, text: 'stream', taskId: 'stream-task', contextId: 'stream-context' },
+      { id: 1, method: 'message/send' as const, text: 'send', contextId: 'send-context' },
+      { id: 2, method: 'message/stream' as const, text: 'stream', contextId: 'stream-context' },
     ]
+    const taskIds: string[] = []
     for (const request of requests) {
       const response = await postJsonRpc(
         harness.app,
@@ -542,18 +543,27 @@ describe('A2A — authenticated sandbox context', () => {
           jsonrpc: '2.0',
           id: request.id,
           method: request.method,
-          params: { message: textMessage(request.text, request.taskId, request.contextId) },
+          params: { message: textMessage(request.text, undefined, request.contextId) },
         },
         apiKeyHeader(),
       )
       expect(response.status).toBe(200)
-      if (request.method === 'message/send') await response.text()
-      else await parseSseEvents(response)
+      if (request.method === 'message/send') {
+        const envelope = (await response.json()) as JSONRPCSuccessResponse<Task>
+        taskIds.push(envelope.result.id)
+      } else {
+        const events = await parseSseEvents(response)
+        const taskId = events[0]?.taskId
+        expect(taskId).toMatch(/^task_/)
+        taskIds.push(taskId as string)
+      }
     }
 
     expect(contexts).toHaveLength(requests.length)
     expect(authorizedThreads).toEqual(requests.map(({ contextId }) => contextId))
-    expect(calls).toEqual(requests.map(({ text, taskId }) => ({ message: text, sessionId: taskId })))
+    expect(calls).toEqual(requests.map(({ text }, index) => ({ message: text, sessionId: taskIds[index] })))
+    expect(taskIds).toHaveLength(requests.length)
+    expect(new Set(taskIds).size).toBe(requests.length)
     for (const [index, request] of requests.entries()) {
       expect(contexts[index]).toMatchObject({
         consumerId: 'consumer_sk_agent_test_key_1',
@@ -582,7 +592,7 @@ describe('A2A — authenticated sandbox context', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: textMessage('send', 'mismatch-task', 'a2a-context') },
+        params: { message: textMessage('send', undefined, 'a2a-context') },
       },
       { ...apiKeyHeader(), 'X-Tangle-Thread-Id': 'header-context' },
     )

--- a/tests/payment-recovery.test.ts
+++ b/tests/payment-recovery.test.ts
@@ -26,6 +26,7 @@ import type {
   SandboxBox,
   SandboxUsageReceipt,
 } from '../src/types'
+import { ServerAssignedTaskStore } from './server-assigned-task-store'
 
 const operatorAddress = '0x1111111111111111111111111111111111111111'
 const commitment = `0x${'ab'.repeat(32)}`
@@ -1082,7 +1083,10 @@ describe('A2A recovery retention', () => {
   it('keeps an expired task until its no-receipt payment reconciles, then restores normal TTL', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-14T00:00:00.000Z'))
-    const taskStore = new InMemoryTaskStore(20)
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(20),
+      'task-503',
+    )
     const recoveryStore = new MemoryPaymentRecoveryStore()
     const settlements: PaymentSettlementInput[] = []
     const operations = new MemoryPaymentOperations({
@@ -1123,7 +1127,6 @@ describe('A2A recovery retention', () => {
             kind: 'message',
             role: 'user',
             messageId: 'message-503',
-            taskId: 'task-503',
             parts: [{ kind: 'text', text: 'run' }],
           },
         },

--- a/tests/pr11-regressions.test.ts
+++ b/tests/pr11-regressions.test.ts
@@ -15,6 +15,7 @@ import { verifyMpp } from '../src/verify'
 import type { AgentMeta, GatewayConfig, SandboxStreamEvent } from '../src/types'
 import { A2A_ERROR_CODES, type Task } from '../src/a2a/types'
 import type { MppConfig } from '../src/types'
+import { ServerAssignedTaskStore } from './server-assigned-task-store'
 
 const operatorAddress = '0x1111111111111111111111111111111111111111'
 const commitment = `0x${'ab'.repeat(32)}`
@@ -91,7 +92,10 @@ function durableConfig(
 
 describe('PR #11 production regressions', () => {
   it('claims one terminal webhook when cancellation races fenced settlement on two workers', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'pr11-push-race',
+    )
     const pushStore = new InMemoryPushNotificationStore()
     const nonceStore = new MemoryNonceStore()
     const recoveryStore = new MemoryPaymentRecoveryStore()
@@ -168,7 +172,6 @@ describe('PR #11 production regressions', () => {
           message: {
             kind: 'message',
             role: 'user',
-            taskId: 'pr11-push-race',
             contextId: 'pr11-push-context',
             messageId: 'pr11-push-message',
             parts: [{ kind: 'text', text: 'run' }],
@@ -177,7 +180,8 @@ describe('PR #11 production regressions', () => {
       }),
     })
     await sandboxReady
-    await pushStore.set('pr11-push-race', { id: 'terminal', url: 'https://hook.example/terminal' })
+    const taskId = taskStore.serverAssignedId!
+    await pushStore.set(taskId, { id: 'terminal', url: 'https://hook.example/terminal' })
 
     const cancel = await canceler.request('/v1/agents/pr11', {
       method: 'POST',
@@ -200,7 +204,7 @@ describe('PR #11 production regressions', () => {
       .result?.status?.state).toBe('completed')
     expect(settlements).toBe(1)
     expect(deliveries).toBe(1)
-    expect(receivedTaskIds).toEqual(['pr11-push-race'])
+    expect(receivedTaskIds).toEqual([taskId])
     expect((await taskStore.get('pr11-push-race'))?.status.state).toBe('completed')
   })
 
@@ -325,7 +329,10 @@ describe('PR #11 production regressions', () => {
   })
 
   it('does not send an unsigned webhook if a production secret disappears at runtime', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'runtime-secret-task',
+    )
     const pushStore = new InMemoryPushNotificationStore()
     let sandboxStarted!: () => void
     const sandboxReady = new Promise<void>((resolve) => { sandboxStarted = resolve })
@@ -376,7 +383,6 @@ describe('PR #11 production regressions', () => {
           message: {
             kind: 'message',
             role: 'user',
-            taskId: 'runtime-secret-task',
             contextId: 'runtime-secret-context',
             messageId: 'runtime-secret-message',
             parts: [{ kind: 'text', text: 'run' }],
@@ -385,7 +391,7 @@ describe('PR #11 production regressions', () => {
       }),
     })
     await sandboxReady
-    await pushStore.set('runtime-secret-task', { id: 'cfg', url: 'https://hook.example/terminal' })
+    await pushStore.set(taskStore.serverAssignedId!, { id: 'cfg', url: 'https://hook.example/terminal' })
     config.a2a!.webhookSecret = undefined
     releaseSandbox()
 
@@ -477,7 +483,10 @@ describe('PR #11 production regressions', () => {
   })
 
   it('does not execute after a cancellation wins on another worker', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'pr11-cancel-race',
+    )
     let sandboxEntered!: () => void
     const sandboxReady = new Promise<void>((resolve) => { sandboxEntered = resolve })
     let releaseSandbox!: () => void
@@ -529,7 +538,6 @@ describe('PR #11 production regressions', () => {
           message: {
             kind: 'message',
             role: 'user',
-            taskId: 'pr11-cancel-race',
             contextId: 'pr11-context',
             messageId: 'pr11-message',
             parts: [{ kind: 'text', text: 'run' }],
@@ -565,7 +573,7 @@ describe('PR #11 production regressions', () => {
     let releaseFence!: () => void
     const fenceReleased = new Promise<void>((resolve) => { releaseFence = resolve })
     let blocked = false
-    const taskStore: TaskStore = {
+    const innerTaskStore: TaskStore = {
       get: (id) => innerStore.get(id),
       put: (task) => innerStore.put(task),
       createIfAbsent: (task) => innerStore.createIfAbsent(task),
@@ -582,6 +590,7 @@ describe('PR #11 production regressions', () => {
       compareAndSetExecution: (expected, next, requestId, now) =>
         innerStore.compareAndSetExecution(expected, next, requestId, now),
     }
+    const taskStore = new ServerAssignedTaskStore(innerTaskStore, 'pr11-active-cancel-race')
     let providerStarted = false
     let releaseProvider!: () => void
     const providerReleased = new Promise<void>((resolve) => { releaseProvider = resolve })
@@ -628,7 +637,6 @@ describe('PR #11 production regressions', () => {
           message: {
             kind: 'message',
             role: 'user',
-            taskId: 'pr11-active-cancel-race',
             contextId: 'pr11-active-cancel-context',
             messageId: 'pr11-active-cancel-message',
             parts: [{ kind: 'text', text: 'run' }],
@@ -670,7 +678,7 @@ describe('PR #11 production regressions', () => {
     let releaseTransition!: () => void
     const transitionReleased = new Promise<void>((resolve) => { releaseTransition = resolve })
     let blocked = false
-    const taskStore: TaskStore = {
+    const innerTaskStore: TaskStore = {
       get: (id) => innerStore.get(id),
       put: (task) => innerStore.put(task),
       createIfAbsent: (task) => innerStore.createIfAbsent(task),
@@ -686,6 +694,7 @@ describe('PR #11 production regressions', () => {
       compareAndSetExecution: (expected, next, requestId, now) =>
         innerStore.compareAndSetExecution(expected, next, requestId, now),
     }
+    const taskStore = new ServerAssignedTaskStore(innerTaskStore, 'submission-lease-task')
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway(durableConfig({
       a2a: { taskStore },
@@ -713,7 +722,6 @@ describe('PR #11 production regressions', () => {
           message: {
             kind: 'message',
             role: 'user',
-            taskId: 'submission-lease-task',
             contextId: 'submission-lease-context',
             messageId: 'submission-lease-message',
             parts: [{ kind: 'text', text: 'run' }],
@@ -797,7 +805,10 @@ describe('PR #11 production regressions', () => {
   })
 
   it('quotes retained A2A history before charging a continuation', async () => {
-    const taskStore = new InMemoryTaskStore()
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'pr11-continuation',
+    )
     let invocations = 0
     const longHistory = 'history '.repeat(500)
     const config: GatewayConfig = {
@@ -829,7 +840,7 @@ describe('PR #11 production regressions', () => {
     }
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway(config))
-    const send = (nonce: string, text: string) => app.request('/v1/agents/pr11', {
+    const send = (nonce: string, text: string, taskId?: string) => app.request('/v1/agents/pr11', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -843,7 +854,7 @@ describe('PR #11 production regressions', () => {
           message: {
             kind: 'message',
             role: 'user',
-            taskId: 'pr11-continuation',
+            ...(taskId ? { taskId } : {}),
             contextId: 'pr11-context',
             messageId: `message-${nonce}`,
             parts: [{ kind: 'text', text }],
@@ -855,7 +866,7 @@ describe('PR #11 production regressions', () => {
     const first = await send('9004', longHistory)
     expect((await first.json() as { result?: { status?: { state?: string } } }).result?.status?.state)
       .toBe('input-required')
-    const second = await send('9005', 'continue')
+    const second = await send('9005', 'continue', 'pr11-continuation')
 
     expect(second.status).toBe(200)
     expect((await second.json() as { result?: { status?: { state?: string } } }).result?.status?.state)

--- a/tests/protocol-guards.test.ts
+++ b/tests/protocol-guards.test.ts
@@ -87,56 +87,123 @@ describe('final payment boundary protocol guards', () => {
     expect(claims).toBe(0)
   })
 
-  it('checks an A2A task state before claiming a payment', async () => {
-    const taskStore = new InMemoryTaskStore()
-    const terminal: Task = {
-      kind: 'task',
-      id: 'existing-task',
-      contextId: 'ctx',
-      status: { state: 'completed', timestamp: new Date().toISOString() },
-      history: [],
-    }
-    await taskStore.put(terminal)
-    let claims = 0
-    const app = new Hono()
-    app.route('/v1/agents', createAgentGateway({
-      resolveAgent: async () => agent,
-      getSandbox: async () => box(),
-      recordUsage: async () => undefined,
-      x402: {
-        operatorAddress,
-        chainId: 1,
-        demoMode: true,
-        authorizePayment: async () => {
-          claims += 1
-          return true
-        },
-      },
-      nonceStore: new MemoryNonceStore(),
-      a2a: { taskStore },
-    }))
-
-    const response = await app.request('/v1/agents/guards', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': paymentHeader('3') },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'message/send',
-        params: {
-          message: {
-            kind: 'message',
-            role: 'user',
-            taskId: terminal.id,
-            parts: [{ kind: 'text', text: 'retry' }],
+  it.each(['message/send', 'message/stream'] as const)(
+    'checks an A2A task state before payment or sandbox work for %s',
+    async (method) => {
+      const taskStore = new InMemoryTaskStore()
+      const terminal: Task = {
+        kind: 'task',
+        id: 'existing-task',
+        contextId: 'ctx',
+        status: { state: 'completed', timestamp: new Date().toISOString() },
+        history: [],
+      }
+      await taskStore.put(terminal)
+      let claims = 0
+      let sandboxRuns = 0
+      const app = new Hono()
+      app.route('/v1/agents', createAgentGateway({
+        resolveAgent: async () => agent,
+        getSandbox: async () => ({
+          async *streamPrompt() {
+            sandboxRuns += 1
+            yield* box().streamPrompt()
+          },
+        }),
+        recordUsage: async () => undefined,
+        x402: {
+          operatorAddress,
+          chainId: 1,
+          demoMode: true,
+          authorizePayment: async () => {
+            claims += 1
+            return true
           },
         },
-      }),
-    })
-    const body = await response.json() as { error?: { code: number } }
-    expect(body.error?.code).toBe(A2A_ERROR_CODES.INVALID_PARAMS)
-    expect(claims).toBe(0)
-  })
+        nonceStore: new MemoryNonceStore(),
+        a2a: { taskStore },
+      }))
+
+      const response = await app.request('/v1/agents/guards', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': paymentHeader('3') },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method,
+          params: {
+            message: {
+              kind: 'message',
+              role: 'user',
+              taskId: terminal.id,
+              parts: [{ kind: 'text', text: 'retry' }],
+            },
+          },
+        }),
+      })
+      const body = await response.json() as { error?: { code: number } }
+      expect(body.error?.code).toBe(A2A_ERROR_CODES.UNSUPPORTED_OPERATION)
+      expect(claims).toBe(0)
+      expect(sandboxRuns).toBe(0)
+    },
+  )
+
+  it.each(['message/send', 'message/stream'] as const)(
+    'rejects an unknown taskId before payment or sandbox work for %s',
+    async (method) => {
+      const taskStore = new InMemoryTaskStore()
+      let claims = 0
+      let sandboxRuns = 0
+      const app = new Hono()
+      app.route('/v1/agents', createAgentGateway({
+        resolveAgent: async () => agent,
+        getSandbox: async () => ({
+          async *streamPrompt() {
+            sandboxRuns += 1
+            yield { type: 'message.part.updated', data: { part: { type: 'text' }, delta: 'unexpected' } }
+          },
+        }),
+        recordUsage: async () => undefined,
+        x402: {
+          operatorAddress,
+          chainId: 1,
+          demoMode: true,
+          authorizePayment: async () => {
+            claims += 1
+            return true
+          },
+        },
+        nonceStore: new MemoryNonceStore(),
+        a2a: { taskStore },
+      }))
+      const taskId = `unknown-${method.replace('/', '-')}`
+
+      const response = await app.request('/v1/agents/guards', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': paymentHeader('4') },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: method,
+          method,
+          params: {
+            message: {
+              kind: 'message',
+              role: 'user',
+              taskId,
+              messageId: `message-${method}`,
+              parts: [{ kind: 'text', text: 'retry' }],
+            },
+          },
+        }),
+      })
+      const body = await response.json() as { error?: { code: number } }
+      expect(response.status).toBe(200)
+      expect(body.error?.code).toBe(A2A_ERROR_CODES.TASK_NOT_FOUND)
+      expect(claims).toBe(0)
+      expect(sandboxRuns).toBe(0)
+      expect(await taskStore.get(taskId)).toBeUndefined()
+    },
+  )
 
   it('rejects a continuation before it can mutate another caller task', async () => {
     const taskStore = new InMemoryTaskStore()

--- a/tests/server-assigned-task-store.ts
+++ b/tests/server-assigned-task-store.ts
@@ -1,0 +1,73 @@
+import type { TaskStore } from '../src/a2a/task-store'
+import type { Task } from '../src/a2a/types'
+
+/**
+ * Test adapter that lets a scenario refer to a server-created task by a
+ * stable fixture name when the response is intentionally blocked.
+ */
+export class ServerAssignedTaskStore implements TaskStore {
+  private assignedId: string | undefined
+
+  constructor(
+    private readonly inner: TaskStore,
+    private readonly alias: string,
+  ) {}
+
+  get serverAssignedId(): string | undefined {
+    return this.assignedId
+  }
+
+  private resolve(id: string): string {
+    return id === this.alias ? this.assignedId ?? id : id
+  }
+
+  get(id: string): Promise<Task | undefined> {
+    return this.inner.get(this.resolve(id))
+  }
+
+  put(task: Task): Promise<void> {
+    return this.inner.put(task)
+  }
+
+  async createIfAbsent(task: Task): Promise<boolean> {
+    const createIfAbsent = this.inner.createIfAbsent
+    if (!createIfAbsent) throw new Error('inner task store must support createIfAbsent')
+    try {
+      const created = await createIfAbsent.call(this.inner, task)
+      if (created && !this.assignedId) this.assignedId = task.id
+      return created
+    } catch (error) {
+      if (!this.assignedId && await this.inner.get(task.id)) this.assignedId = task.id
+      throw error
+    }
+  }
+
+  compareAndSet(expected: Task, next: Task): Promise<boolean> {
+    if (!this.inner.compareAndSet) throw new Error('inner task store must support compareAndSet')
+    return this.inner.compareAndSet(
+      { ...expected, id: this.resolve(expected.id) },
+      { ...next, id: this.resolve(next.id) },
+    )
+  }
+
+  compareAndSetExecution(
+    expected: Task,
+    next: Task,
+    requestId: string,
+    now: number,
+  ): Promise<boolean> {
+    if (!this.inner.compareAndSetExecution) {
+      throw new Error('inner task store must support compareAndSetExecution')
+    }
+    return this.inner.compareAndSetExecution(
+      { ...expected, id: this.resolve(expected.id) },
+      { ...next, id: this.resolve(next.id) },
+      requestId,
+      now,
+    )
+  }
+
+  delete(id: string): Promise<void> {
+    return this.inner.delete(this.resolve(id))
+  }
+}


### PR DESCRIPTION
## Summary
- reject unknown `message.taskId` values with A2A `TASK_NOT_FOUND` for `message/send` and `message/stream`
- assign task IDs only when the initial message omits `taskId`
- return `UNSUPPORTED_OPERATION` for follow-ups to terminal or working tasks
- update long-horizon and race fixtures to use server-assigned task IDs

## Proof
- `pnpm test -- --run --reporter=dot` — 24 files, 386 tests passed
- `pnpm typecheck` — passed
- `pnpm build` — ESM and DTS builds passed
- unknown-ID tests assert 0 payment claims, 0 sandbox runs, and no stored task for both messaging methods
- branch rebased onto `origin/main` `ce3b7ac` (`v0.8.8`)

No package publish performed.
