### PR TITLE
test(a2a): use server-assigned task id in failure proof

### DIFF
--- a/.agent/release-progress.md
+++ b/.agent/release-progress.md
@@ -9,23 +9,25 @@
 - Credential files: GitHub trusted publishing and npm provenance workflow
 
 ## Local State
-- Branch: chore/release-agent-gateway-0.8.9
-- Commit: b39a117 (merged failure-contract fix)
+- Branch: fix/gateway-release-test-compat
+- Commit: 13d37cc (merged 0.8.9 release commit)
 - Dirty files: clean at start
 - Gates planned: focused failure tests, full typecheck/test/build, PR review, npm version proof
 
 ## Remote State
 - Host/provider: GitHub Actions + npm trusted publishing
 - Current live artifact: @tangle-network/agent-gateway@0.8.8
-- Current service status: package registry state to verify before release
+- Current service status: v0.8.9 tag workflow failed in Test before publication
 - Last smoke result: pending
 
 ## Decision
 - Build path: tag-triggered GitHub Actions publish
 - Reason: repository workflow owns verification, provenance, and npm publication
 - Expected duration: minutes after merge and tag push
-- Fallback/rollback: retain v0.8.8 and diagnose failed workflow before retrying
+- Fallback/rollback: retain v0.8.8; publish v0.8.10 after the test compatibility fix
 
 ## Timeline
 - 2026-09-01: confirmed branch starts at origin/main v0.8.8; implementation and release verification in progress
 - 2026-09-01: PR #24 merged as b39a117 after verify passed; release target is 0.8.9
+- 2026-09-01: v0.8.9 tag run 33541628022 failed because PR #25 server-owned IDs invalidated the new preallocated-id test; npm publication was skipped
+- 2026-09-01: fixing the test against the current task-id contract before publishing v0.8.10

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -21,6 +21,7 @@ import type {
 import { createAgentGateway } from '../src/middleware'
 import { MemoryNonceStore } from '../src/nonce-store'
 import { MemoryRateLimitStore } from '../src/rate-limit'
+import { ServerAssignedTaskStore } from './server-assigned-task-store'
 import type {
   AgentMeta,
   ApiKeyInfo,
@@ -430,7 +431,12 @@ describe('A2A — message/send', () => {
   })
 
   it('persists an A2A task as failed for the structured sandbox error shape', async () => {
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'structured-failure-task',
+    )
     const harness = buildHarness({
+      a2a: { taskStore },
       getSandbox: async () => ({
         async *streamPrompt() {
           yield structuredSandboxFailure
@@ -446,7 +452,7 @@ describe('A2A — message/send', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'message/send',
-        params: { message: textMessage('connect', 'structured-failure-task', 'structured-failure-context') },
+        params: { message: textMessage('connect', undefined, 'structured-failure-context') },
       },
       apiKeyHeader(),
     )
@@ -464,6 +470,7 @@ describe('A2A — message/send', () => {
     )
     const task = (await taskResponse.json() as JSONRPCSuccessResponse<Task>).result
     expect(task.status.state).toBe('failed')
+    expect(task.id).not.toBe('structured-failure-task')
     expect(task.artifacts).toBeUndefined()
     expect(harness.usage).toHaveLength(0)
     expect(harness.settlements).toHaveLength(0)


### PR DESCRIPTION
## Summary
- Adapt the structured sandbox failure proof to the server-owned task-id contract from PR #25.
- Resolve the created task through a test-only alias while asserting the client did not choose its ID.
- Unblock the 0.8.10 trusted release after v0.8.9 verification found this test incompatibility.

## Verification
- `pnpm exec vitest run tests/a2a.test.ts` (25/25)
- `pnpm run test` (389/389 across 24 files)
- `pnpm run typecheck`
- `pnpm run build`
