### PR TITLE
chore(release): bump agent gateway to 0.8.10

### DIFF
--- a/.agent/release-progress.md
+++ b/.agent/release-progress.md
@@ -9,25 +9,25 @@
 - Credential files: GitHub trusted publishing and npm provenance workflow
 
 ## Local State
-- Branch: fix/gateway-release-test-compat
-- Commit: 13d37cc (merged 0.8.9 release commit)
+- Branch: chore/release-agent-gateway-0.8.10
+- Commit: c008808 (merged release-test compatibility fix)
 - Dirty files: clean at start
 - Gates planned: focused failure tests, full typecheck/test/build, PR review, npm version proof
 
 ## Remote State
 - Host/provider: GitHub Actions + npm trusted publishing
 - Current live artifact: @tangle-network/agent-gateway@0.8.8
-- Current service status: v0.8.9 tag workflow failed in Test before publication
+- Current service status: v0.8.9 tag workflow failed in Test before publication; v0.8.10 pending
 - Last smoke result: pending
 
 ## Decision
 - Build path: tag-triggered GitHub Actions publish
 - Reason: repository workflow owns verification, provenance, and npm publication
 - Expected duration: minutes after merge and tag push
-- Fallback/rollback: retain v0.8.8; publish v0.8.10 after the test compatibility fix
+- Fallback/rollback: retain v0.8.8; diagnose and retry only after a failed v0.8.10 workflow
 
 ## Timeline
 - 2026-09-01: confirmed branch starts at origin/main v0.8.8; implementation and release verification in progress
 - 2026-09-01: PR #24 merged as b39a117 after verify passed; release target is 0.8.9
 - 2026-09-01: v0.8.9 tag run 33541628022 failed because PR #25 server-owned IDs invalidated the new preallocated-id test; npm publication was skipped
-- 2026-09-01: fixing the test against the current task-id contract before publishing v0.8.10
+- 2026-09-01: PR #27 merged as c008808; corrected test passes 389/389 and release target is 0.8.10

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "packageManager": "pnpm@10.28.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump `@tangle-network/agent-gateway` from 0.8.9 to 0.8.10.
- Publishes the merged terminal sandbox failure contract fix from PR #24.
- Includes the server-assigned task-id test compatibility fix from PR #27.

## Verification
- `pnpm run test` (389/389 on current main)
- `pnpm run typecheck`
- `pnpm run build`
- `npm view @tangle-network/agent-gateway@0.8.10 version` is absent before publication, as expected.
