### PR TITLE
fix(a2a): authorize task aliases by agent identity

### DIFF
--- a/src/a2a/handler.ts
+++ b/src/a2a/handler.ts
@@ -554,9 +554,6 @@ async function authorizeTaskAccess(
   const requestedAgentSlug = c.req.param('slug') ?? ''
   const origin = readTaskOrigin(task)
   if (origin) {
-    if (origin.agentSlug !== requestedAgentSlug) {
-      return c.json(fail(req.id, A2A_ERROR_CODES.TASK_ACCESS_DENIED, 'task belongs to a different agent'), 403)
-    }
     const requestedAgent = await deps.config.resolveAgent(requestedAgentSlug)
     if (!requestedAgent || requestedAgent.id !== origin.agentId) {
       return c.json(fail(req.id, A2A_ERROR_CODES.TASK_ACCESS_DENIED, 'task belongs to a different agent'), 403)

--- a/tests/a2a-lifecycle.test.ts
+++ b/tests/a2a-lifecycle.test.ts
@@ -290,6 +290,32 @@ describe('A2A lifecycle recovery and ownership', () => {
     expect((await taskStore.get('task-origin-bound'))?.status.state).toBe('completed')
   })
 
+  it('allows task access through an alias that resolves to the originating agent', async () => {
+    const taskStore = new ServerAssignedTaskStore(
+      new InMemoryTaskStore(),
+      'task-alias-bound',
+    )
+    const alias = 'workspace-agent-alias'
+    const app = new Hono()
+    app.route('/v1/agents', createAgentGateway({
+      ...gatewayConfig(taskStore),
+      resolveAgent: async (slug) => slug === agentA.slug || slug === alias ? agentA : null,
+    }))
+
+    const created = await post(
+      app,
+      agentA.slug,
+      body('message/send'),
+      { 'X-Payment-Signature': paymentHeader('904') },
+    )
+    const createdBody = await created.json() as { result?: Task }
+    expect(createdBody).toMatchObject({ result: { status: { state: 'completed' } } })
+
+    const fetched = await post(app, alias, body('tasks/get', 'task-alias-bound'))
+    expect(fetched.status).toBe(200)
+    expect((await fetched.json() as { result?: Task }).result?.id).toBe(taskStore.serverAssignedId)
+  })
+
   it('expires a task created before payment authorization can finish', async () => {
     class CrashAfterCreateStore implements TaskStore {
       private readonly inner = new InMemoryTaskStore()


### PR DESCRIPTION
The Agent Card may expose a workspace alias while task metadata records the canonical slug. `tasks/get` and `tasks/cancel` then reject the same agent task.

This change resolves the requested route and authorizes by the stable agent ID. Different agent IDs still fail closed.

Proof:
- `pnpm vitest run tests/a2a-lifecycle.test.ts -t "allows task access through an alias|rejects task access and continuation through a different originating agent"`
- `pnpm typecheck`
- reproduced in production GTM: workspace-card route returned -32008; canonical slug returned 200 for the same task.