### PR TITLE
chore(release): bump agent gateway to 0.8.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "packageManager": "pnpm@10.28.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Publishes the stable-agent-identity task authorization fix merged in #30.