### PR TITLE
chore(release): bump agent gateway to 0.8.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "packageManager": "pnpm@10.28.0",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Publishes the shared SQL gateway stores and safety fixes merged in #32.\n\nProof: 422 tests passed, typecheck passed, build passed, and CI tests Node 24.18.0 plus the supported minimum Node 22.13.0.