### PR TITLE
chore(release): 0.8.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "packageManager": "pnpm@10.28.0",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
Publishes the durable API-key request policy from #35.

Proof: typecheck, 430 tests, build, and package dry run all passed.