### PR TITLE
fix(streaming): settle usage after client disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ app.route('/v1/agents', createAgentGateway({
 }))
 ```
 
+Configure `continueOnDisconnect` when the host keeps agent turns alive after a caller closes the API stream.
+The gateway then consumes the final usage receipt and settles payment in background time.
+When omitted, a disconnect aborts sandbox work.
+Create the gateway inside the Worker request when you need its execution context:
+
+```ts
+const gateway = createAgentGateway({
+  ...gatewayConfig,
+  continueOnDisconnect: (task) => ctx.waitUntil(task),
+})
+```
+
 Use `sqlApiKeyStoreSchemaStatements()` in deploy-time SQL migrations.
 Use `sqlGatewayUsageStoreSchemaStatements()` for retry-safe usage attribution.
 Use `sqlTaskStoreSchemaStatements()` for the durable A2A task table.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -87,6 +87,12 @@ export function createAgentGateway(inputConfig: CreateAgentGatewayConfig) {
       'createAgentGateway: unauthenticatedInputTokenBound must be a non-negative safe integer',
     )
   }
+  if (
+    config.continueOnDisconnect !== undefined &&
+    typeof config.continueOnDisconnect !== 'function'
+  ) {
+    throw new Error('createAgentGateway: continueOnDisconnect must be a function')
+  }
   if (config.inputTokenBound && isX402AuthEnabled(config) &&
       config.unauthenticatedInputTokenBound === undefined) {
     throw new Error(
@@ -474,14 +480,21 @@ function streamChatCompletions(
     rateLimitRemaining,
     maxOutputTokens,
   } = authz
-  let outputText = ''
   let usage: import('./types').SandboxUsageReceipt | undefined
   let workObserved = false
+  let clientDisconnected = false
   const requestSignal = c.req.raw.signal
   const abortController = new AbortController()
   const abortFromRequest = () => abortController.abort()
-  if (requestSignal.aborted) abortFromRequest()
-  else requestSignal.addEventListener('abort', abortFromRequest, { once: true })
+  const continueOnDisconnect = config.continueOnDisconnect
+  if (!continueOnDisconnect) {
+    if (requestSignal.aborted) abortFromRequest()
+    else requestSignal.addEventListener('abort', abortFromRequest, { once: true })
+  }
+  let finishBackgroundTask!: () => void
+  const backgroundTask = new Promise<void>((resolve) => {
+    finishBackgroundTask = resolve
+  })
   const ctx: RequestContext = {
     requestId,
     agentSlug: agent.slug,
@@ -492,8 +505,7 @@ function streamChatCompletions(
     async start(controller) {
       const encoder = new TextEncoder()
       const sendChunk = (delta: string, role?: string) => {
-        if (controller.desiredSize === null) return
-        outputText += delta
+        if (clientDisconnected || controller.desiredSize === null) return
         const chunk: ChatCompletionChunk = {
           id: `chatcmpl-${Date.now()}`,
           object: 'chat.completion.chunk',
@@ -504,7 +516,7 @@ function streamChatCompletions(
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`))
       }
       const sendKeepalive = () => {
-        if (controller.desiredSize === null) return
+        if (clientDisconnected || controller.desiredSize === null) return
         controller.enqueue(encoder.encode(': keep-alive\n\n'))
       }
       const keepaliveTimer = setInterval(sendKeepalive, 15_000)
@@ -554,7 +566,7 @@ function streamChatCompletions(
           model: agent.slug,
           choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
         }
-        if (controller.desiredSize !== null) {
+        if (!clientDisconnected && controller.desiredSize !== null) {
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(done)}\n\n`))
           controller.enqueue(encoder.encode('data: [DONE]\n\n'))
         }
@@ -581,7 +593,11 @@ function streamChatCompletions(
             releaseError instanceof Error ? releaseError.message : String(releaseError),
           )
         }
-        if (!abortController.signal.aborted && controller.desiredSize !== null) {
+        if (
+          !clientDisconnected &&
+          !abortController.signal.aborted &&
+          controller.desiredSize !== null
+        ) {
           controller.enqueue(
             encoder.encode(
               `data: ${JSON.stringify({ error: { message: safeMessage, type: 'server_error' } })}\n\n`,
@@ -590,14 +606,28 @@ function streamChatCompletions(
         }
       } finally {
         clearInterval(keepaliveTimer)
-        requestSignal.removeEventListener('abort', abortFromRequest)
-        if (controller.desiredSize !== null) controller.close()
+        if (!continueOnDisconnect) {
+          requestSignal.removeEventListener('abort', abortFromRequest)
+        }
+        finishBackgroundTask()
+        if (!clientDisconnected && controller.desiredSize !== null) controller.close()
       }
     },
     cancel() {
-      abortController.abort()
+      clientDisconnected = true
+      if (!continueOnDisconnect) abortController.abort()
     },
   })
+
+  if (continueOnDisconnect) {
+    try {
+      continueOnDisconnect(backgroundTask)
+    } catch (error) {
+      abortController.abort()
+      void stream.cancel()
+      throw error
+    }
+  }
 
   return new Response(stream, {
     headers: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -299,6 +299,13 @@ export interface GatewayConfig {
    */
   recordUsage: (event: GatewayUsageEvent) => Promise<void>
 
+  /**
+   * Keep the gateway task alive after the HTTP client disconnects.
+   * Pass a Worker execution context's `waitUntil` method here.
+   * When omitted, disconnecting aborts sandbox work.
+   */
+  continueOnDisconnect?: (task: Promise<void>) => void
+
   /** x402 payment configuration */
   x402: X402Config
 

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -724,6 +724,72 @@ describe('POST /:slug/chat/completions — auth paths', () => {
     expect(sandboxSignal?.aborted).toBe(true)
   })
 
+  it('records final usage after reader cancellation when background continuation is configured', async () => {
+    let sandboxSignal: AbortSignal | undefined
+    let releaseSandbox!: () => void
+    const mayFinish = new Promise<void>((resolve) => { releaseSandbox = resolve })
+    const backgroundTasks: Promise<void>[] = []
+    let sandboxFinished = false
+    const { app, usage } = buildHarness({
+      continueOnDisconnect: (task) => { backgroundTasks.push(task) },
+      getSandbox: async () => ({
+        async *streamPrompt(_message: string, opts?: { signal?: AbortSignal }) {
+          sandboxSignal = opts?.signal
+          yield { type: 'message.part.updated', data: { part: { type: 'text' }, delta: 'partial' } }
+          await mayFinish
+          yield { type: 'message.part.updated', data: { part: { type: 'text' }, delta: ' complete' } }
+          yield {
+            type: 'sandbox.usage',
+            data: {
+              usage: {
+                inputTokens: 3,
+                outputTokens: 2,
+                reasoningTokens: 1,
+                toolTokens: 0,
+                toolCallCount: 0,
+                providerCostUsd: 0.00012,
+                budgetEnforced: true,
+              },
+            },
+          }
+          sandboxFinished = true
+        },
+      }),
+    })
+    const response = await app.request('/v1/agents/test-agent/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer sk_agent_background',
+      },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+    })
+    const reader = response.body!.getReader()
+    const decoder = new TextDecoder()
+    let received = ''
+    while (!received.includes('partial')) {
+      const { value, done } = await reader.read()
+      if (done) break
+      received += decoder.decode(value)
+    }
+
+    expect(received).toContain('partial')
+    await reader.cancel()
+    releaseSandbox()
+    expect(backgroundTasks).toHaveLength(1)
+    await Promise.all(backgroundTasks)
+
+    expect(sandboxSignal?.aborted).toBe(false)
+    expect(sandboxFinished).toBe(true)
+    expect(usage).toHaveLength(1)
+    expect(usage[0]).toMatchObject({
+      inputTokens: 3,
+      outputTokens: 2,
+      reasoningTokens: 1,
+      providerCostUsd: 0.00012,
+    })
+  })
+
   it('releases a durable payment when cancellation wins after authorization but before sandbox start', async () => {
     const controller = new AbortController()
     const operations = new MemoryPaymentOperations()


### PR DESCRIPTION
## What changed

- add an opt-in background continuation callback for OpenAI-compatible streams
- keep the sandbox iterator and payment settlement alive after a client closes its reader
- retain cancellation as the default when the callback is absent
- stop response writes after disconnect without stopping usage collection

## Why

Agent-app keeps persisted chat turns alive after an API viewer disconnects. The gateway previously stopped consuming that turn, so it could miss the final usage receipt and retain payment ownership.

## Proof

- Node 24: 447/447 tests pass
- Node 22.13: 447/447 tests pass
- focused middleware: 66/66 tests pass
- typecheck and build pass
- the new end-user cancel flow records input, output, reasoning, and provider cost after the reader closes
- the existing cancel-by-default flow still aborts the sandbox iterator