### PR TITLE
chore(release): 0.8.16

### DIFF
--- a/.agent/release-progress.md
+++ b/.agent/release-progress.md
@@ -5,26 +5,26 @@
 - Live URL: https://www.npmjs.com/package/@tangle-network/agent-gateway
 - Live service/process: npm package `@tangle-network/agent-gateway`
 - Artifact path: tag-triggered GitHub Actions publish workflow
-- Rollback artifact/path: retain v0.8.14; publish a follow-up patch if needed
+- Rollback artifact/path: retain v0.8.15; publish a follow-up patch if needed
 - Credential files: GitHub trusted publishing and npm provenance workflow
 
 ## Local State
-- Branch: chore/release-agent-gateway-0.8.15-20260902
-- Commit: 90ed0fd (merged authorization fence and A2A opt-out)
+- Branch: chore/release-0.8.16-20260902
+- Commit: 408dac6 (merged background usage settlement)
 - Dirty files: clean at release start
 - Gates planned: version-only diff, full typecheck/test/build, PR review, npm version proof
 
 ## Remote State
 - Host/provider: GitHub Actions + npm trusted publishing
-- Current live artifact: @tangle-network/agent-gateway@0.8.14
-- Current service status: merged source is 90ed0fd; release workflow runs from an exact v0.8.15 tag
+- Current live artifact: @tangle-network/agent-gateway@0.8.15
+- Current service status: merged source is 408dac6; release workflow runs from an exact v0.8.16 tag
 - Last smoke result: pending this release
 
 ## Decision
 - Build path: tag-triggered GitHub Actions publish
 - Reason: repository workflow owns verification, provenance, and npm publication
 - Expected duration: minutes after merge and tag push
-- Fallback/rollback: retain v0.8.14; diagnose and retry only after a failed v0.8.15 workflow
+- Fallback/rollback: retain v0.8.15; diagnose and retry only after a failed v0.8.16 workflow
 
 ## Timeline
 - 2026-09-01: confirmed release branch starts at origin/main 5095f58, version 0.8.13
@@ -38,3 +38,5 @@
 - 2026-09-02: PR #39 merged as 23d9f8a; async input bounds and the root pricing export landed
 - 2026-09-02: PR #40 merged as 90ed0fd; dynamic bounds now run after payment and consumer authorization, and `a2a: false` disables A2A routes
 - 2026-09-02: npm registry returned version/latest 0.8.14 before the 0.8.15 release
+- 2026-09-02: PR #43 merged as 408dac6; canceled clients no longer prevent final usage settlement when the host opts in
+- 2026-09-02: local Node 22.13 and Node 24.13 test runs each passed 447/447 tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "packageManager": "pnpm@10.28.0",
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
## Release

Publishes the merged background-settlement fix and dependency security updates as `@tangle-network/agent-gateway@0.8.16`.

## Proof

- Node 24: 447/447 tests pass
- Node 22.13: 447/447 tests pass
- typecheck and build pass
- package version and release target both name 0.8.16