### PR TITLE
feat(gateway)!: require explicit consumer authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ await usageStore.migrate()
 app.route('/v1/agents', createAgentGateway({
   resolveAgent: loadPublishedAgent,
   getSandbox: openAgentSandbox,
+  authorizeConsumer: authorizeAgentAccess,
   recordUsage: usageStore.recordUsage,
   claimApiKeyRequest: createApiKeyRequestClaim(apiKeyStore),
   settlePayment: createApiKeyUsageSettlement(apiKeyStore),
@@ -52,6 +53,12 @@ app.route('/v1/agents', createAgentGateway({
   verifyApiKey: (authHeader) => verifyApiKeyFromStore(authHeader, apiKeyStore),
 }))
 ```
+
+Starting with 0.9.0, every gateway requires an explicit `authorizeConsumer` policy.
+Authentication or payment does not grant access to a private workspace.
+For private agents, resolve workspace and thread permissions from the verified consumer identity.
+Public services may explicitly allow consumers only when their execution environment contains approved public resources.
+Omitting the policy rejects gateway construction.
 
 Configure `continueOnDisconnect` when the host keeps agent turns alive after a caller closes the API stream.
 The gateway then consumes the final usage receipt and settles payment in background time.

--- a/docs/a2a-long-horizon.md
+++ b/docs/a2a-long-horizon.md
@@ -116,7 +116,7 @@ export default {
     const pushStore = new SqlPushNotificationStore(db)
 
     const gw = createAgentGateway({
-  authorizeConsumer: authorizeAgentAccess,
+      authorizeConsumer: authorizeAgentAccess,
       // ... your existing config ...
       a2a: {
         taskStore,

--- a/docs/a2a-long-horizon.md
+++ b/docs/a2a-long-horizon.md
@@ -116,6 +116,7 @@ export default {
     const pushStore = new SqlPushNotificationStore(db)
 
     const gw = createAgentGateway({
+  authorizeConsumer: authorizeAgentAccess,
       // ... your existing config ...
       a2a: {
         taskStore,
@@ -227,6 +228,7 @@ import {
 } from '@tangle-network/agent-gateway'
 
 createAgentGateway({
+  authorizeConsumer: authorizeAgentAccess,
   // ...
   a2a: {
     pushStore: new SqlPushNotificationStore(d1ToSqlAdapter(env.DB)),
@@ -314,6 +316,7 @@ If you need at-least-once or exactly-once delivery, wrap the gateway's fetcher w
 
 ```ts
 createAgentGateway({
+  authorizeConsumer: authorizeAgentAccess,
   a2a: {
     pushStore: yourStore,
     webhookSecret: secret,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.8.17",
+  "version": "0.9.0",
   "packageManager": "pnpm@10.28.0",
   "engines": {
     "node": ">=22.13.0"

--- a/src/dispatch-authorization.ts
+++ b/src/dispatch-authorization.ts
@@ -394,13 +394,13 @@ export async function authenticateAndGuard(
     requestId,
     ...(threadId ? { threadId } : {}),
   })
-  if (!authz.allow) {
+  if (authz?.allow !== true) {
     return c.json(
       {
         error: {
-          message: authz.reason,
+          message: authz?.allow === false ? authz.reason : 'Invalid consumer authorization decision',
           type: 'authorization_denied',
-          code: authz.code,
+          code: authz?.allow === false ? authz.code : 'invalid_authorization_decision',
         },
       },
       { status: 403, headers: { 'X-Request-Id': requestId } },

--- a/src/dispatch-authorization.ts
+++ b/src/dispatch-authorization.ts
@@ -386,27 +386,25 @@ export async function authenticateAndGuard(
     }
   }
 
-  if (config.authorizeConsumer) {
-    const authz = await config.authorizeConsumer(agent, {
-      method: paymentMethod,
-      consumerId: consumerId,
-      keyId: keyInfo?.keyId,
-      ownerId: keyInfo?.ownerId,
-      requestId,
-      ...(threadId ? { threadId } : {}),
-    })
-    if (!authz.allow) {
-      return c.json(
-        {
-          error: {
-            message: authz.reason,
-            type: 'authorization_denied',
-            code: authz.code,
-          },
+  const authz = await config.authorizeConsumer(agent, {
+    method: paymentMethod,
+    consumerId: consumerId,
+    keyId: keyInfo?.keyId,
+    ownerId: keyInfo?.ownerId,
+    requestId,
+    ...(threadId ? { threadId } : {}),
+  })
+  if (!authz.allow) {
+    return c.json(
+      {
+        error: {
+          message: authz.reason,
+          type: 'authorization_denied',
+          code: authz.code,
         },
-        { status: 403, headers: { 'X-Request-Id': requestId } },
-      )
-    }
+      },
+      { status: 403, headers: { 'X-Request-Id': requestId } },
+    )
   }
 
   const authorizedQuote = await resolveAuthorizedInputQuote(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -49,6 +49,9 @@ import { isApiKeyAuthEnabled, isMppAuthEnabled, isX402AuthEnabled } from './veri
  *   POST /:slug/chat/completions  — OpenAI-compatible chat endpoint (paid)
  */
 export function createAgentGateway(inputConfig: CreateAgentGatewayConfig) {
+  if (typeof inputConfig.authorizeConsumer !== 'function') {
+    throw new Error('createAgentGateway: authorizeConsumer must be an explicit authorization function')
+  }
   let config: GatewayConfig = inputConfig.x402
     ? inputConfig
     : {

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,11 +277,11 @@ export interface GatewayConfig {
   getSandbox: (agent: AgentMeta, context?: GatewaySandboxContext) => Promise<SandboxBox>
 
   /**
-   * Optional host authorization hook fired after payment verification
+   * Required host authorization hook fired after payment verification
    * and before sandbox resolution. Use it for per-agent allowlists,
    * per-consumer quotas, contract scope checks, and instance ownership.
    */
-  authorizeConsumer?: (
+  authorizeConsumer: (
     agent: AgentMeta,
     consumer: {
       method: PaymentMethod

--- a/tests/a2a-atomicity.test.ts
+++ b/tests/a2a-atomicity.test.ts
@@ -121,6 +121,7 @@ function atomicityConfig(
     },
   }
   return {
+    authorizeConsumer: async () => ({ allow: true }),
     resolveAgent: async (slug) => (slug === agent.slug ? agent : null),
     getSandbox: async () => sandbox,
     recordUsage: async () => { counters.records += 1 },
@@ -285,6 +286,7 @@ describe('A2A task atomicity and restart recovery', () => {
     await taskStore.put(task)
 
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async (slug) => (slug === agent.slug ? agent : null),
       getSandbox: async () => ({ async *streamPrompt() { throw new Error('restart recovery must not execute sandbox') } }),
       recordUsage: async () => { counters.records += 1 },
@@ -433,6 +435,7 @@ describe('A2A task atomicity and restart recovery', () => {
       },
     })
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async (slug) => (slug === agent.slug ? agent : null),
       getSandbox: async () => ({ async *streamPrompt() { throw new Error('recovery must not execute sandbox') } }),
       recordUsage: async () => { records += 1 },

--- a/tests/a2a-lifecycle.test.ts
+++ b/tests/a2a-lifecycle.test.ts
@@ -77,6 +77,7 @@ function standardSandbox(): SandboxBox {
 
 function gatewayConfig(taskStore: TaskStore, overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return {
+    authorizeConsumer: async () => ({ allow: true }),
     resolveAgent: async (slug) => (slug === agentA.slug ? agentA : null),
     getSandbox: async () => standardSandbox(),
     recordUsage: async () => undefined,

--- a/tests/a2a-long-horizon.test.ts
+++ b/tests/a2a-long-horizon.test.ts
@@ -140,6 +140,7 @@ function buildHarness(
   const fetchMock = vi.fn(async () => new Response('ok', { status: 200 }))
 
   const gw = createAgentGateway({
+    authorizeConsumer: async () => ({ allow: true }),
     resolveAgent: async (slug) => (slug === agent.slug ? agent : null),
     getSandbox: async () => sandbox,
     recordUsage: async () => {},

--- a/tests/a2a-payment-races.test.ts
+++ b/tests/a2a-payment-races.test.ts
@@ -131,6 +131,7 @@ describe('A2A payment ownership races', () => {
     const authorizationReleased = new Promise<void>((resolve) => { finishAuthorization = resolve })
     let runs = 0
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -200,6 +201,7 @@ describe('A2A payment ownership races', () => {
     const recoveryStore = new MemoryPaymentRecoveryStore()
     let runs = 0
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -287,6 +289,7 @@ describe('A2A payment ownership races', () => {
 
     const operations = new BlockingExecutionOperations()
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         streamPrompt() {
@@ -364,6 +367,7 @@ describe('A2A payment ownership races', () => {
       },
     }
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => box,
       recordUsage: async () => undefined,
@@ -410,6 +414,7 @@ describe('A2A payment ownership races', () => {
     let releaseSandbox!: () => void
     const sandboxReleased = new Promise<void>((resolve) => { releaseSandbox = resolve })
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -493,6 +498,7 @@ describe('A2A payment ownership races', () => {
       onReclaim: async () => undefined,
     })
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -581,6 +587,7 @@ describe('A2A payment ownership races', () => {
       onReclaim: async () => undefined,
     })
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -655,6 +662,7 @@ describe('A2A payment ownership races', () => {
     const never = new Promise<void>(() => undefined)
     let sandboxSignal: AbortSignal | undefined
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt(_message, opts) {
@@ -729,6 +737,7 @@ describe('A2A payment ownership races', () => {
       },
     }
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => box,
       recordUsage: async () => undefined,
@@ -820,6 +829,7 @@ describe('A2A payment ownership races', () => {
       onReclaim: async () => { recoveryAttempts += 1 },
     })
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -943,6 +953,7 @@ describe('A2A payment ownership races', () => {
       onReclaim: async () => { recoveryCalls += 1 },
     })
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         streamPrompt() {
@@ -1054,6 +1065,7 @@ describe('A2A payment ownership races', () => {
       },
     })
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         streamPrompt() {
@@ -1133,6 +1145,7 @@ describe('A2A payment ownership races', () => {
     let rows = 0
     let firstCall = true
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -1232,6 +1245,7 @@ describe('A2A payment ownership races', () => {
     lifecycle.confirmationGate = new Promise<void>((resolve) => { releaseConfirmation = resolve })
     let runs = 0
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -1301,6 +1315,7 @@ describe('A2A payment ownership races', () => {
     const taskStore = new InMemoryTaskStore()
     const lifecycle = new A2AChargeLifecycle()
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -1364,6 +1379,7 @@ describe('A2A payment ownership races', () => {
     let recordCalls = 0
     let firstAcknowledgement = true
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -98,6 +98,7 @@ function buildHarness(
   const settlements: Array<{ method: string; cost: number }> = []
 
   const gw = createAgentGateway({
+    authorizeConsumer: async () => ({ allow: true }),
     resolveAgent: async (slug) => (slug === agent.slug ? agent : null),
     getSandbox: async () => sandbox,
     recordUsage: async (evt) => {
@@ -221,6 +222,7 @@ describe('A2A — AgentCard discovery', () => {
   it('advertises only Bearer when payment transports are disabled', async () => {
     const agent = makeAgent()
     const gateway = createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => new StubSandbox(['ok']),
       recordUsage: async () => undefined,

--- a/tests/consumer-policy.test.ts
+++ b/tests/consumer-policy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createAgentGateway } from '../src/middleware'
+
+// Deliberately use Reflect.apply to exercise JavaScript callers that bypass
+// the required TypeScript configuration field.
+describe('explicit consumer authorization policy', () => {
+  it.each([undefined, null, true, 'allow'])('rejects invalid policy %s before any host work', (policy) => {
+    const resolveAgent = vi.fn(async () => null)
+    const getSandbox = vi.fn(async () => ({
+      async* streamPrompt() { yield { type: 'finish' } },
+    }))
+    const verifyApiKey = vi.fn(async () => null)
+    const recordUsage = vi.fn(async () => {})
+    expect(() => Reflect.apply(createAgentGateway, undefined, [{
+      resolveAgent, getSandbox, verifyApiKey, recordUsage,
+      ...(policy === undefined ? {} : { authorizeConsumer: policy }),
+    }])).toThrow('authorizeConsumer must be an explicit authorization function')
+    expect(resolveAgent).not.toHaveBeenCalled()
+    expect(getSandbox).not.toHaveBeenCalled()
+    expect(verifyApiKey).not.toHaveBeenCalled()
+    expect(recordUsage).not.toHaveBeenCalled()
+  })
+})

--- a/tests/consumer-policy.test.ts
+++ b/tests/consumer-policy.test.ts
@@ -20,4 +20,37 @@ describe('explicit consumer authorization policy', () => {
     expect(verifyApiKey).not.toHaveBeenCalled()
     expect(recordUsage).not.toHaveBeenCalled()
   })
+
+  it.each([undefined, null, { allow: 'false' }, { allow: 1 }, {}, 'allow'])(
+    'rejects malformed decision %j before request claims and sandbox access', async (decision) => {
+      const getSandbox = vi.fn(async () => ({ async* streamPrompt() { yield { type: 'finish' } } }))
+      const claimApiKeyRequest = vi.fn(async () => ({
+        allowed: true, minuteRemaining: 1, dailyRemaining: 1,
+        minuteResetAt: Date.now() + 60_000, dailyResetAt: Date.now() + 86_400_000,
+      }))
+      const recordUsage = vi.fn(async () => {})
+      const gateway = Reflect.apply(createAgentGateway, undefined, [{
+        resolveAgent: async () => ({
+          id: 'agent', ownerId: 'owner', slug: 'agent', enabled: true,
+          pricePerTokenUsd: 0.00002, platformFeePercent: 0.2,
+          sandboxEndpoint: null, remoteSandboxId: null, remoteBearerToken: null,
+        }),
+        authorizeConsumer: async () => decision,
+        verifyApiKey: async () => ({ keyId: 'key', consumerId: 'apikey:key', scopes: ['chat'] }),
+        getSandbox, claimApiKeyRequest, recordUsage,
+        a2a: false,
+      }])
+      const response = await gateway.request('/agent/chat/completions', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer sk_agent_synthetic', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: [{ role: 'user', content: 'Read private data' }] }),
+      })
+      expect(response.status).toBe(403)
+      expect(await response.json()).toMatchObject({ error: { code: 'invalid_authorization_decision' } })
+      expect(claimApiKeyRequest).not.toHaveBeenCalled()
+      expect(getSandbox).not.toHaveBeenCalled()
+      expect(recordUsage).not.toHaveBeenCalled()
+    },
+  )
+
 })

--- a/tests/integration-x402.test.ts
+++ b/tests/integration-x402.test.ts
@@ -214,6 +214,7 @@ function buildHarness(chunks = ['Hello', ', ', 'world!']): Harness {
   }
 
   const gw = createAgentGateway({
+    authorizeConsumer: async () => ({ allow: true }),
     resolveAgent: async (slug) => (slug === agent.slug ? agent : null),
     getSandbox: async () => new ReplySandbox(chunks),
     recordUsage: async (evt) => { usage.push(evt) },

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -127,6 +127,7 @@ function buildHarness(cfg: Partial<GatewayConfig> = {}, chunks = ['Hello', ', ',
   const settlements: Array<{ method: string; consumerId: string; requestId: string; cost: number }> = []
 
   const gw = createAgentGateway({
+    authorizeConsumer: async () => ({ allow: true }),
     resolveAgent: async (slug) => (slug === agent.slug ? agent : null),
     getSandbox: async () => sandbox,
     recordUsage: async (evt) => { usage.push(evt) },
@@ -262,6 +263,7 @@ describe('GET /:slug/chat/completions (discovery)', () => {
   it('supports production API-key-only gateways without advertising x402', async () => {
     const sandbox = new StubSandbox(['api only'])
     const gateway = createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async (slug) => slug === 'test-agent' ? makeAgent() : null,
       getSandbox: async () => sandbox,
       recordUsage: async () => undefined,
@@ -1718,6 +1720,7 @@ describe('POST /:slug/chat/completions — malformed input', () => {
 describe('createAgentGateway — production-config guard', () => {
   it('refuses to boot when neither verifySigner nor demoMode is set', () => {
     expect(() => createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => null,
       getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
       recordUsage: async () => { /* unused */ },
@@ -1727,6 +1730,7 @@ describe('createAgentGateway — production-config guard', () => {
 
   it('boots when demoMode: true is set explicitly (test path)', () => {
     expect(() => createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => null,
       getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
       recordUsage: async () => { /* unused */ },
@@ -1738,6 +1742,7 @@ describe('createAgentGateway — production-config guard', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     try {
       const gateway = createAgentGateway({
+        authorizeConsumer: async () => ({ allow: true }),
         resolveAgent: async () => null,
         getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
         recordUsage: async () => { /* unused */ },
@@ -1764,6 +1769,7 @@ describe('createAgentGateway — production-config guard', () => {
 
   it('boots when verifySigner is supplied (production path)', () => {
     expect(() => createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => null,
       getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
       recordUsage: async () => { /* unused */ },
@@ -1773,6 +1779,7 @@ describe('createAgentGateway — production-config guard', () => {
 
   it('requires an explicit version when durable payment operations are configured', () => {
     expect(() => createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => null,
       getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
       recordUsage: async () => { /* unused */ },
@@ -1787,6 +1794,7 @@ describe('createAgentGateway — production-config guard', () => {
 
   it('requires a durable recovery outbox for production payment protocol version 2', () => {
     expect(() => createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => null,
       getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
       recordUsage: async () => { /* unused */ },
@@ -1802,6 +1810,7 @@ describe('createAgentGateway — production-config guard', () => {
 
   it('keeps older custom A2A task stores source-compatible', () => {
     expect(() => createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => null,
       getSandbox: async () => ({ async *streamPrompt() { /* unused */ } }),
       recordUsage: async () => { /* unused */ },

--- a/tests/observer.test.ts
+++ b/tests/observer.test.ts
@@ -176,6 +176,7 @@ describe('Observer integrated with middleware', () => {
   function buildApp(observer: GatewayObserver) {
     const sandbox = new StubSandbox(['hello'])
     const gw = createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => makeAgent(),
       getSandbox: async () => sandbox,
       recordUsage: async () => {},
@@ -256,6 +257,7 @@ describe('Observer integrated with middleware', () => {
     const events: unknown[] = []
     const sandbox = new StubSandbox(['ok'])
     const gw = createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => makeAgent(),
       getSandbox: async () => sandbox,
       recordUsage: async () => {},

--- a/tests/payment-operations.test.ts
+++ b/tests/payment-operations.test.ts
@@ -72,6 +72,7 @@ describe('version 2 payment operations', () => {
       onReclaim: async () => undefined,
     })
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -532,6 +533,7 @@ describe('bounded request pricing and sandbox receipts', () => {
       },
     }
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => box,
       recordUsage: async () => undefined,
@@ -575,6 +577,7 @@ describe('bounded request pricing and sandbox receipts', () => {
       },
     }
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => box,
       recordUsage: async () => undefined,
@@ -609,6 +612,7 @@ describe('bounded request pricing and sandbox receipts', () => {
       },
     }
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => box,
       recordUsage: async () => undefined,
@@ -665,6 +669,7 @@ describe('bounded request pricing and sandbox receipts', () => {
       },
     }
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => box,
       recordUsage: async () => undefined,
@@ -723,6 +728,7 @@ describe('bounded request pricing and sandbox receipts', () => {
       },
     }
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => box,
       recordUsage: async () => undefined,
@@ -768,6 +774,7 @@ describe('bounded request pricing and sandbox receipts', () => {
       },
     }
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => box,
       recordUsage: async () => undefined,
@@ -810,6 +817,7 @@ describe('bounded request pricing and sandbox receipts', () => {
       },
     }
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         streamPrompt: () => ({ [Symbol.asyncIterator]: () => iterator }),
@@ -865,6 +873,7 @@ describe('bounded request pricing and sandbox receipts', () => {
         },
       }
       const config: GatewayConfig = {
+        authorizeConsumer: async () => ({ allow: true }),
         resolveAgent: async () => agent,
         getSandbox: async () => ({
           streamPrompt: () => ({ [Symbol.asyncIterator]: () => iterator }),
@@ -948,6 +957,7 @@ async function collectUsage(
   } = {},
 ): Promise<SandboxUsageReceipt> {
   const config: GatewayConfig = {
+    authorizeConsumer: async () => ({ allow: true }),
     resolveAgent: async () => agent,
     getSandbox: async () => ({
       async *streamPrompt() {

--- a/tests/payment-recovery.test.ts
+++ b/tests/payment-recovery.test.ts
@@ -140,6 +140,7 @@ function mppRecoveryConfig(
   timing: { leaseMs?: number; retryDelayMs?: number } = {},
 ): GatewayConfig {
   return {
+    authorizeConsumer: async () => ({ allow: true }),
     resolveAgent: async () => agent,
     getSandbox: async () => ({ async *streamPrompt() {} }),
     recordUsage: async () => undefined,
@@ -262,6 +263,7 @@ describe('generic MPP charge lifecycle', () => {
     let runs = 0
     let legacySettlements = 0
     const app = mount({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -318,6 +320,7 @@ describe('generic MPP charge lifecycle', () => {
     const recoveryStore = new MemoryPaymentRecoveryStore()
     let runs = 0
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({ async *streamPrompt() { runs += 1 } }),
       recordUsage: async () => undefined,
@@ -454,6 +457,7 @@ describe('generic MPP charge lifecycle', () => {
     const observerGate = new Promise<void>((resolve) => { releaseObserver = resolve })
     let runs = 0
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -514,6 +518,7 @@ describe('generic MPP charge lifecycle', () => {
     let runs = 0
     const secret = 'spt_same_secret'
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -576,6 +581,7 @@ describe('generic MPP charge lifecycle', () => {
     const usage: GatewayUsageEvent[] = []
     let starts = 0
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         streamPrompt() {
@@ -626,6 +632,7 @@ describe('generic MPP charge lifecycle', () => {
     const recoveryStore = new MemoryPaymentRecoveryStore()
     let runs = 0
     const app = mount({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({ async *streamPrompt() { runs += 1 } }),
       recordUsage: async () => undefined,
@@ -665,6 +672,7 @@ describe('durable OpenAI recovery', () => {
     const recoveryStore = new MemoryPaymentRecoveryStore()
     let sandboxCalls = 0
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -720,6 +728,7 @@ describe('durable OpenAI recovery', () => {
     }
     const operations = new FailingExecutionOperations()
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({ async *streamPrompt() {} }),
       recordUsage: async () => undefined,
@@ -765,6 +774,7 @@ describe('durable OpenAI recovery', () => {
     let recordAtSandboxStart: Awaited<ReturnType<typeof recoveryStore.get>>
     const operationId = `x402:${commitment}:501`
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -849,6 +859,7 @@ describe('durable OpenAI recovery', () => {
     })
     const usage = new Map<string, GatewayUsageEvent>()
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt(_message, options) {
@@ -934,6 +945,7 @@ describe('durable OpenAI recovery', () => {
     })
     const usage: GatewayUsageEvent[] = []
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -992,6 +1004,7 @@ describe('durable OpenAI recovery', () => {
     })
     let usageAttempts = 0
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({ async *streamPrompt() {} }),
       recordUsage: async () => {
@@ -1098,6 +1111,7 @@ describe('A2A recovery retention', () => {
       onReclaim: async () => undefined,
     })
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {

--- a/tests/pr11-regressions.test.ts
+++ b/tests/pr11-regressions.test.ts
@@ -79,6 +79,7 @@ function durableConfig(
   overrides: Partial<GatewayConfig> = {},
 ): GatewayConfig {
   return {
+    authorizeConsumer: async () => ({ allow: true }),
     resolveAgent: async () => agent,
     getSandbox: async () => sandbox(),
     recordUsage: async () => undefined,
@@ -138,6 +139,7 @@ describe('PR #11 production regressions', () => {
     ): Promise<Response> => webhook.fetch(new Request('https://receiver.local/terminal', init))
 
     const config = (sandbox: GatewayConfig['getSandbox']): GatewayConfig => ({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: sandbox,
       recordUsage: async () => undefined,
@@ -509,6 +511,7 @@ describe('PR #11 production regressions', () => {
     let runs = 0
 
     const makeConfig = (worker: 'runner' | 'canceler'): GatewayConfig => ({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => {
         if (worker === 'runner') {
@@ -611,6 +614,7 @@ describe('PR #11 production regressions', () => {
     const providerReleased = new Promise<void>((resolve) => { releaseProvider = resolve })
 
     const makeConfig = (worker: 'runner' | 'canceler'): GatewayConfig => ({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -827,6 +831,7 @@ describe('PR #11 production regressions', () => {
     let invocations = 0
     const longHistory = 'history '.repeat(500)
     const config: GatewayConfig = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -1317,6 +1322,7 @@ describe('PR #11 production regressions', () => {
   it('keeps A2A unavailable when production omits its task store', async () => {
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => sandbox(),
       recordUsage: async () => undefined,
@@ -1345,6 +1351,7 @@ describe('PR #11 production regressions', () => {
     }
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => sandbox(),
       recordUsage: async () => undefined,
@@ -1394,6 +1401,7 @@ describe('PR #11 production regressions', () => {
       const app = new Hono()
       const taskStore = new InMemoryTaskStore()
       app.route('/v1/agents', createAgentGateway({
+        authorizeConsumer: async () => ({ allow: true }),
         resolveAgent: async () => agent,
         getSandbox: async () => sandbox([
           { type: 'input-required', data: { inputRequired: { prompt: 'Need one more detail' } } },

--- a/tests/protocol-guards.test.ts
+++ b/tests/protocol-guards.test.ts
@@ -103,6 +103,7 @@ describe('final payment boundary protocol guards', () => {
       let sandboxRuns = 0
       const app = new Hono()
       app.route('/v1/agents', createAgentGateway({
+        authorizeConsumer: async () => ({ allow: true }),
         resolveAgent: async () => agent,
         getSandbox: async () => ({
           async *streamPrompt() {
@@ -156,6 +157,7 @@ describe('final payment boundary protocol guards', () => {
       let sandboxRuns = 0
       const app = new Hono()
       app.route('/v1/agents', createAgentGateway({
+        authorizeConsumer: async () => ({ allow: true }),
         resolveAgent: async () => agent,
         getSandbox: async () => ({
           async *streamPrompt() {
@@ -218,6 +220,7 @@ describe('final payment boundary protocol guards', () => {
     let sandboxRuns = 0
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {
@@ -272,6 +275,7 @@ describe('final payment boundary protocol guards', () => {
     await taskStore.put(paused)
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => box(),
       recordUsage: async () => undefined,
@@ -328,6 +332,7 @@ describe('final payment boundary protocol guards', () => {
     let releaseLegacy!: () => void
     const legacyRelease = new Promise<void>((resolve) => { releaseLegacy = resolve })
     const shared = {
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => box(),
       recordUsage: async () => undefined,
@@ -400,6 +405,7 @@ describe('final payment boundary protocol guards', () => {
     const apps = stores.map((operations) => {
       const app = new Hono()
       app.route('/v1/agents', createAgentGateway({
+        authorizeConsumer: async () => ({ allow: true }),
         resolveAgent: async () => agent,
         getSandbox: async () => ({
           async *streamPrompt() {
@@ -458,6 +464,7 @@ describe('final payment boundary protocol guards', () => {
     let runs = 0
     const app = new Hono()
     app.route('/v1/agents', createAgentGateway({
+      authorizeConsumer: async () => ({ allow: true }),
       resolveAgent: async () => agent,
       getSandbox: async () => ({
         async *streamPrompt() {


### PR DESCRIPTION
A gateway without authorizeConsumer previously treated successful payment authentication as permission to execute the agent. Require an explicit host authorization callback and reject construction when it is missing or invalid. Every request now runs that policy before claims or sandbox access; only the boolean decision `allow: true` permits execution. Malformed decisions fail closed with 403 and a stable error code.

This is the 0.9.0 breaking configuration contract. Workspace hosts retain their existing membership and thread policies. Public services must explicitly allow consumers and keep private resources out of their execution environment. Published-only discovery remains unchanged. No new audience framework or x402 configuration is introduced.

Validation: all 463 tests pass, with typecheck and build on the pinned Node 24.18.0. Four missing/invalid callback regressions failed before the constructor guard; six malformed decision regressions failed before strict boolean authorization. Both now pass and assert zero request claims, sandbox calls and usage records. Existing payment, workspace-owner, deny-before-reserve and A2A tests remain green. Public protocol fixtures now declare their intentional allow policy. Independent review findings were fixed; CI verifies Node 24.18.0 and 22.13.0 before merge.
