### PR TITLE
feat(gateway)!: unify inclusive token accounting and explicit caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,20 @@ OpenAI chat requests return a JSON `chat.completion` by default; set `stream: tr
 Set `apiKeyPurchaseUrl` to override the API-key purchase link in payment errors; without it, `baseUrl` keeps the `/agents/{slug}/api-keys` default.
 An unpaid request receives `required_amount`, `currency_decimals`, and `max_output_tokens` in the 402 response.
 Sandbox adapters should emit a complete `sandbox.usage` receipt.
+Input and output token counts are inclusive provider totals across all model calls.
+Input totals include tool-result messages and applicable cache accounting.
+Output totals include reasoning tokens when the provider reports them as completion tokens.
+Reasoning and tool token fields are optional measured subsets; never add them again when billing.
+The gateway charges the greater of inclusive token charges and provider cost.
+It does not invent reasoning or tool token caps when the host omits them.
+Explicit detail caps, including zero, remain enforced and require the corresponding measured receipt field.
+Missing detail fields remain absent; absence does not mean measured zero.
+
+This accounting contract changes in 0.11.0.
+Normalize an adapter's provider totals before upgrading; do not report visible text alone as inclusive output.
+New payment outbox and A2A finalization records store `tokenAccounting: 'inclusive'`.
+Historical records without that field retain additive settlement arithmetic during recovery.
+Do not backfill the marker onto historical pending operations or replace their original quoted amounts.
 Requests with a version 2 operation or generic MPP charge reject missing receipts.
 API-key requests keep the legacy visible-token estimate path.
 recordUsage must atomically upsert by event.requestId; recovery may retry an event after its acknowledgement is lost.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "packageManager": "pnpm@10.28.0",
   "engines": {
     "node": ">=22.13.0"

--- a/src/a2a/task-finalization.ts
+++ b/src/a2a/task-finalization.ts
@@ -37,6 +37,8 @@ const FINALIZATION_LEASE_MS = 5 * 60 * 1000
 export type FinalizationState = 'completed' | 'input-required' | 'canceled'
 
 export interface FinalizationRecord {
+  /** Absent on historical records with additive reasoning/tool charges. */
+  tokenAccounting?: 'inclusive'
   version: 1
   lease: { id: string; expiresAt: number }
   agentSlug: string
@@ -97,6 +99,7 @@ export function buildFinalizationRecord(
   const operation = authz.paymentOperation
   return {
     version: 1,
+    tokenAccounting: 'inclusive',
     lease: { id: cryptoRandomId(), expiresAt: Date.now() + FINALIZATION_LEASE_MS },
     agentSlug: authz.agent.slug,
     requestId: authz.requestId,
@@ -128,6 +131,7 @@ export function readFinalizationRecord(task: Task): FinalizationRecord | undefin
   if (!raw || typeof raw !== 'object') return undefined
   const record = raw as Partial<FinalizationRecord>
   if (
+    (record.tokenAccounting !== undefined && record.tokenAccounting !== 'inclusive') ||
     record.version !== 1 ||
     !record.lease ||
     typeof record.lease.id !== 'string' ||
@@ -354,6 +358,7 @@ export async function recoverFinalizationIfNeeded(
     }
 
     const authz: AuthorizedRequest = {
+      tokenAccounting: renewed.tokenAccounting ?? 'additive',
       agent,
       consumerId: renewed.consumerId,
       paymentMethod: renewed.paymentMethod,

--- a/src/api-key-budget.ts
+++ b/src/api-key-budget.ts
@@ -8,7 +8,7 @@ export function apiKeyReservationQuote(authz: AuthorizedRequest, config: Gateway
   if (!config.apiKeyReservationLifecycle) throw new ApiKeyRequestClaimUnavailableError('API key spending reservations are not configured')
   const budget = authz.executionBudget
   return apiKeySettlementCostCents(Math.max(
-    (budget.maxInputTokens + budget.maxOutputTokens + budget.maxReasoningTokens + budget.maxToolTokens) * authz.agent.pricePerTokenUsd,
+    (budget.maxInputTokens + budget.maxOutputTokens) * authz.agent.pricePerTokenUsd,
     budget.maxProviderCostUsd,
   ))
 }

--- a/src/dispatch-input-bound.ts
+++ b/src/dispatch-input-bound.ts
@@ -28,12 +28,12 @@ function quote(
   messageInputBound: number,
 ): InputQuote {
   const maxProviderCostUsd = state.maxProviderCostUsd ??
-    (inputTokens + maxOutputTokens + state.maxReasoningTokens + state.maxToolTokens) * agent.pricePerTokenUsd
+    (inputTokens + maxOutputTokens) * agent.pricePerTokenUsd
   const executionBudget: SandboxExecutionBudget = {
     maxInputTokens: inputTokens,
     maxOutputTokens,
-    maxReasoningTokens: state.maxReasoningTokens,
-    maxToolTokens: state.maxToolTokens,
+    ...(state.maxReasoningTokens !== undefined ? { maxReasoningTokens: state.maxReasoningTokens } : {}),
+    ...(state.maxToolTokens !== undefined ? { maxToolTokens: state.maxToolTokens } : {}),
     maxToolCalls: state.maxToolCalls,
     maxProviderCostUsd,
   }

--- a/src/dispatch-payment-recovery.ts
+++ b/src/dispatch-payment-recovery.ts
@@ -43,6 +43,7 @@ export async function preparePaymentRecovery(
     state: 'claiming',
     payment,
     attribution: {
+      tokenAccounting: 'inclusive',
       requestId: authz.requestId,
       agentId: authz.agent.id,
       agentSlug: authz.agent.slug,

--- a/src/dispatch-pricing.ts
+++ b/src/dispatch-pricing.ts
@@ -61,23 +61,46 @@ export function requiredX402Amount(
   if (!Number.isFinite(maxProviderCostUsd) || maxProviderCostUsd < 0) {
     throw new Error('maxProviderCostUsd must be finite and non-negative')
   }
-  const tokenCount = inputTokens + maxOutputTokens + maxReasoningTokens + maxToolTokens
+  const tokenCount = inputTokens + maxOutputTokens
   if (!Number.isSafeInteger(tokenCount)) throw new Error('token budget exceeds safe integer range')
   return amountForTokens(pricePerTokenUsd, tokenCount, currencyDecimals, maxProviderCostUsd)
+}
+
+/** Historical recovery alone retains additive token accounting. */
+export function billableTokenCount(
+  inputTokens: number,
+  outputTokens: number,
+  reasoningTokens?: number,
+  toolTokens?: number,
+  tokenAccounting: 'inclusive' | 'additive' = 'inclusive',
+): number {
+  if (tokenAccounting === 'additive' && (reasoningTokens === undefined || toolTokens === undefined)) {
+    throw new Error('historical additive accounting requires complete token details')
+  }
+  for (const count of [inputTokens, outputTokens, reasoningTokens, toolTokens]) {
+    if (count !== undefined && (!Number.isSafeInteger(count) || count < 0)) {
+      throw new Error('billable token count is invalid')
+    }
+  }
+  const total = inputTokens + outputTokens + (tokenAccounting === 'additive'
+    ? (reasoningTokens ?? 0) + (toolTokens ?? 0) : 0)
+  if (!Number.isSafeInteger(total) || total < 0) throw new Error('billable token total is invalid')
+  return total
 }
 
 export function actualX402Amount(
   pricePerTokenUsd: number,
   inputTokens: number,
   outputTokens: number,
-  reasoningTokens: number,
-  toolTokens: number,
+  reasoningTokens: number | undefined,
+  toolTokens: number | undefined,
   currencyDecimals = 6,
   providerCostUsd = 0,
+  tokenAccounting: 'inclusive' | 'additive' = 'inclusive',
 ): bigint {
   return amountForTokens(
     pricePerTokenUsd,
-    inputTokens + outputTokens + reasoningTokens + toolTokens,
+    billableTokenCount(inputTokens, outputTokens, reasoningTokens, toolTokens, tokenAccounting),
     currencyDecimals,
     providerCostUsd,
   )

--- a/src/dispatch-sandbox.ts
+++ b/src/dispatch-sandbox.ts
@@ -132,13 +132,11 @@ export async function* dispatchSandboxStreamRich(
     const executionBudget: SandboxExecutionBudget = sandboxContext?.apiKeyReservation?.executionBudget ?? {
       maxInputTokens: maxInputTokens ?? maximumBillableInputTokens(agent, userMessage),
       maxOutputTokens: outputLimit,
-      maxReasoningTokens: config.executionBudget?.maxReasoningTokens ?? outputLimit,
-      maxToolTokens: config.executionBudget?.maxToolTokens ?? outputLimit,
+      ...(config.executionBudget?.maxReasoningTokens !== undefined ? { maxReasoningTokens: config.executionBudget.maxReasoningTokens } : {}),
+      ...(config.executionBudget?.maxToolTokens !== undefined ? { maxToolTokens: config.executionBudget.maxToolTokens } : {}),
       maxToolCalls: config.executionBudget?.maxToolCalls ?? 8,
       maxProviderCostUsd: config.executionBudget?.maxProviderCostUsd ?? (
-        (maxInputTokens ?? maximumBillableInputTokens(agent, userMessage)) + outputLimit +
-          (config.executionBudget?.maxReasoningTokens ?? outputLimit) +
-          (config.executionBudget?.maxToolTokens ?? outputLimit)
+        (maxInputTokens ?? maximumBillableInputTokens(agent, userMessage)) + outputLimit
       ) * agent.pricePerTokenUsd,
     }
     const { prepared, promptOptions } = await prepareApiKeyPrompt(box, userMessage, consumerId,
@@ -377,10 +375,10 @@ function enforceUsageBudget(
   if (usage.outputTokens !== undefined && usage.outputTokens > budget.maxOutputTokens) {
     throw new Error('sandbox exceeded max output tokens')
   }
-  if (usage.reasoningTokens !== undefined && usage.reasoningTokens > budget.maxReasoningTokens) {
+  if (budget.maxReasoningTokens !== undefined && usage.reasoningTokens !== undefined && usage.reasoningTokens > budget.maxReasoningTokens) {
     throw new Error('sandbox exceeded max reasoning tokens')
   }
-  if (usage.toolTokens !== undefined && usage.toolTokens > budget.maxToolTokens) {
+  if (budget.maxToolTokens !== undefined && usage.toolTokens !== undefined && usage.toolTokens > budget.maxToolTokens) {
     throw new Error('sandbox exceeded max tool tokens')
   }
   if (usage.toolCallCount !== undefined && usage.toolCallCount > budget.maxToolCalls) {
@@ -395,13 +393,17 @@ function finalizeUsage(
   parts: Partial<SandboxUsageReceipt>,
   budget: SandboxExecutionBudget,
 ): SandboxUsageReceipt {
-  const fields = ['inputTokens', 'outputTokens', 'reasoningTokens', 'toolTokens', 'toolCallCount', 'providerCostUsd', 'budgetEnforced'] as const
+  const fields = ['inputTokens', 'outputTokens', 'toolCallCount', 'providerCostUsd', 'budgetEnforced'] as const
   if (fields.some((field) => parts[field] === undefined)) {
     throw new Error('sandbox did not provide a complete usage receipt')
   }
+  if ((budget.maxReasoningTokens !== undefined && parts.reasoningTokens === undefined)
+    || (budget.maxToolTokens !== undefined && parts.toolTokens === undefined)) {
+    throw new Error('sandbox did not provide usage for an explicit token cap')
+  }
   const usage = parts as SandboxUsageReceipt
   for (const field of ['inputTokens', 'outputTokens', 'reasoningTokens', 'toolTokens', 'toolCallCount'] as const) {
-    if (!Number.isSafeInteger(usage[field]) || usage[field] < 0) {
+    if (usage[field] !== undefined && (!Number.isSafeInteger(usage[field]) || usage[field]! < 0)) {
       throw new Error(`sandbox usage field ${field} is invalid`)
     }
   }
@@ -412,7 +414,7 @@ function finalizeUsage(
     throw new Error('sandbox usage budget flag is invalid')
   }
   if (!Number.isSafeInteger(
-    usage.inputTokens + usage.outputTokens + usage.reasoningTokens + usage.toolTokens,
+    usage.inputTokens + usage.outputTokens,
   )) {
     throw new Error('sandbox usage token total exceeds safe integer range')
   }
@@ -431,14 +433,14 @@ function completeLegacyUsage(
   const usage = {
     inputTokens: parts.inputTokens ?? estimateTokens(userMessage),
     outputTokens: parts.outputTokens ?? estimateTokens(outputText),
-    reasoningTokens: parts.reasoningTokens ?? 0,
-    toolTokens: parts.toolTokens ?? 0,
+    ...(parts.reasoningTokens !== undefined ? { reasoningTokens: parts.reasoningTokens } : {}),
+    ...(parts.toolTokens !== undefined ? { toolTokens: parts.toolTokens } : {}),
     toolCallCount: parts.toolCallCount ?? 0,
     providerCostUsd: parts.providerCostUsd ?? 0,
     budgetEnforced: false,
   }
   if (!Number.isSafeInteger(
-    usage.inputTokens + usage.outputTokens + usage.reasoningTokens + usage.toolTokens,
+    usage.inputTokens + usage.outputTokens,
   )) {
     throw new Error('sandbox usage token total exceeds safe integer range')
   }
@@ -465,8 +467,6 @@ function completeUsage(
   const complete = [
     'inputTokens',
     'outputTokens',
-    'reasoningTokens',
-    'toolTokens',
     'toolCallCount',
     'providerCostUsd',
   ] as const

--- a/src/dispatch-settlement.ts
+++ b/src/dispatch-settlement.ts
@@ -1,5 +1,5 @@
 import { type GatewayObserver, type RequestContext } from './observer'
-import { actualX402Amount } from './dispatch-pricing'
+import { actualX402Amount, billableTokenCount } from './dispatch-pricing'
 import {
   assertX402V1SettlementSafe,
   markRecoveryReconciled,
@@ -29,9 +29,8 @@ export async function settleAndRecord(
   const settlementBasis = options.settlementBasis ?? 'usage-receipt'
   await markRecoverySettling(authz, usage, settlementBasis, config)
   if (options.usageAlreadyRecorded) await markRecoveryUsageRecorded(authz, config)
-  const tokenCost = (
-    usage.inputTokens + usage.outputTokens + usage.reasoningTokens + usage.toolTokens
-  ) * agent.pricePerTokenUsd
+  const tokenCost = billableTokenCount(usage.inputTokens, usage.outputTokens,
+    usage.reasoningTokens, usage.toolTokens, authz.tokenAccounting) * agent.pricePerTokenUsd
   const totalCost = Math.max(tokenCost, usage.providerCostUsd)
   const ownerEarned = totalCost * (1 - agent.platformFeePercent)
   const platformFee = totalCost * agent.platformFeePercent
@@ -68,6 +67,7 @@ export async function settleAndRecord(
         usage.toolTokens,
         config.x402.currencyDecimals,
         usage.providerCostUsd,
+        authz.tokenAccounting ?? 'inclusive',
       )
       if (options.paymentAlreadySettled) {
         if (

--- a/src/dispatch-types.ts
+++ b/src/dispatch-types.ts
@@ -22,8 +22,8 @@ export interface GatewayState {
   maxLen: number
   maxOutputTokens: number
   defaultOutputTokens: number
-  maxReasoningTokens: number
-  maxToolTokens: number
+  maxReasoningTokens?: number
+  maxToolTokens?: number
   maxToolCalls: number
   maxProviderCostUsd?: number
   obs?: GatewayObserver
@@ -31,6 +31,8 @@ export interface GatewayState {
 
 /** Successful output from the request authorization pipeline. */
 export interface AuthorizedRequest {
+  /** Only historical recovery records use additive accounting. Live requests use inclusive totals. */
+  tokenAccounting?: 'inclusive' | 'additive'
   agent: AgentMeta
   consumerId: string
   paymentMethod: PaymentMethod

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -114,11 +114,11 @@ export function createAgentGateway(inputConfig: CreateAgentGatewayConfig) {
   }
   const executionBudget = config.executionBudget
   for (const [name, value] of [
-    ['maxReasoningTokens', executionBudget?.maxReasoningTokens ?? maxOutputTokens],
-    ['maxToolTokens', executionBudget?.maxToolTokens ?? maxOutputTokens],
+    ['maxReasoningTokens', executionBudget?.maxReasoningTokens],
+    ['maxToolTokens', executionBudget?.maxToolTokens],
     ['maxToolCalls', executionBudget?.maxToolCalls ?? 8],
   ] as const) {
-    if (!Number.isSafeInteger(value) || value < 0) {
+    if (value !== undefined && (!Number.isSafeInteger(value) || value < 0)) {
       throw new Error(`createAgentGateway: executionBudget.${name} must be a non-negative safe integer`)
     }
   }
@@ -214,8 +214,8 @@ export function createAgentGateway(inputConfig: CreateAgentGatewayConfig) {
     maxLen: config.maxMessageLength ?? 8000,
     maxOutputTokens,
     defaultOutputTokens,
-    maxReasoningTokens: config.executionBudget?.maxReasoningTokens ?? maxOutputTokens,
-    maxToolTokens: config.executionBudget?.maxToolTokens ?? maxOutputTokens,
+    maxReasoningTokens: config.executionBudget?.maxReasoningTokens,
+    maxToolTokens: config.executionBudget?.maxToolTokens,
     maxToolCalls: config.executionBudget?.maxToolCalls ?? 8,
     maxProviderCostUsd: config.executionBudget?.maxProviderCostUsd,
     obs: config.observer,

--- a/src/payment-operations.ts
+++ b/src/payment-operations.ts
@@ -1,6 +1,7 @@
 import type {
   PaymentSettlementBasis,
   SandboxUsageReceipt,
+  SandboxExecutionBudget,
 } from './payment-types'
 
 /** Version negotiated by gateways that use durable payment operations. */
@@ -49,14 +50,7 @@ export interface PaymentAuthorizationContext {
   agentId: string
   requiredAmount: bigint
   maxOutputTokens: number
-  executionBudget: {
-    maxInputTokens: number
-    maxOutputTokens: number
-    maxReasoningTokens: number
-    maxToolTokens: number
-    maxToolCalls: number
-    maxProviderCostUsd: number
-  }
+  executionBudget: SandboxExecutionBudget
 }
 
 export interface PaymentSettlementInput {

--- a/src/payment-recovery-worker.ts
+++ b/src/payment-recovery-worker.ts
@@ -338,7 +338,11 @@ function baseUnitsToNumber(amount: bigint, decimals: number): number {
 
 function authorizedRequest(record: PaymentRecoveryRecord): AuthorizedRequest {
   const attribution = record.attribution
+  if (attribution.tokenAccounting !== undefined && attribution.tokenAccounting !== 'inclusive') {
+    throw new Error('unsupported payment token accounting basis')
+  }
   return {
+    tokenAccounting: attribution.tokenAccounting ?? 'additive',
     agent: recoveryAgent(record),
     consumerId: attribution.consumerId,
     paymentMethod: attribution.paymentMethod,
@@ -435,7 +439,7 @@ async function persistRecoveredUsage(
   config: GatewayConfig,
   now: number,
 ): Promise<PaymentRecoveryRecord> {
-  assertRecoveryUsage(usage)
+  assertRecoveryUsage(usage, record.attribution.tokenAccounting ?? 'additive')
   return updateOwnedPaymentRecovery(
     config.paymentRecovery!.store,
     record.id,
@@ -457,7 +461,7 @@ async function persistRecoveredUsage(
   )
 }
 
-function assertRecoveryUsage(usage: SandboxUsageReceipt): void {
+function assertRecoveryUsage(usage: SandboxUsageReceipt, tokenAccounting: 'inclusive' | 'additive'): void {
   for (const [name, value] of [
     ['inputTokens', usage.inputTokens],
     ['outputTokens', usage.outputTokens],
@@ -465,7 +469,8 @@ function assertRecoveryUsage(usage: SandboxUsageReceipt): void {
     ['toolTokens', usage.toolTokens],
     ['toolCallCount', usage.toolCallCount],
   ] as const) {
-    if (!Number.isSafeInteger(value) || value < 0) {
+    if (value === undefined && tokenAccounting === 'inclusive' && (name === 'reasoningTokens' || name === 'toolTokens')) continue
+    if (value === undefined || !Number.isSafeInteger(value) || value < 0) {
       throw new Error(`payment recovery ${name} must be a non-negative safe integer`)
     }
   }

--- a/src/payment-recovery.ts
+++ b/src/payment-recovery.ts
@@ -36,6 +36,8 @@ export interface SerializedPaymentOperation {
 }
 
 export interface PaymentRecoveryAttribution {
+  /** Absent on historical rows, whose reasoning/tool counts were billed additively. */
+  tokenAccounting?: 'inclusive'
   requestId: string
   agentId: string
   agentSlug: string

--- a/src/payment-types.ts
+++ b/src/payment-types.ts
@@ -1,19 +1,23 @@
 export type PaymentMethod = 'x402' | 'mpp' | 'apikey' | 'none'
 
+/** Inclusive totals bound all calls, retries, and tool messages within one execution. */
 export interface SandboxExecutionBudget {
   maxInputTokens: number
   maxOutputTokens: number
-  maxReasoningTokens: number
-  maxToolTokens: number
+  /** Optional subset cap. Omission does not add a separate reasoning budget. */
+  maxReasoningTokens?: number
+  /** Optional subset cap for tool-attributed tokens already included in input/output. */
+  maxToolTokens?: number
   maxToolCalls: number
   maxProviderCostUsd: number
 }
 
+/** Input/output are inclusive provider totals. Optional reasoning/tool counts are subsets, never extra charges. */
 export interface SandboxUsageReceipt {
   inputTokens: number
   outputTokens: number
-  reasoningTokens: number
-  toolTokens: number
+  reasoningTokens?: number
+  toolTokens?: number
   toolCallCount: number
   providerCostUsd: number
   /** True only when the provider/adapter enforced every supplied budget. */
@@ -31,13 +35,13 @@ export interface GatewayUsageEvent {
   paymentMethod: PaymentMethod
   inputTokens: number
   outputTokens: number
-  /** Optional in 0.7.2 so 0.7.1 event constructors remain source-compatible. */
+  /** Optional measured detail. Omitted when the adapter cannot report it. */
   reasoningTokens?: number
-  /** Optional in 0.7.2 so 0.7.1 event constructors remain source-compatible. */
+  /** Optional measured detail. Omitted when the adapter cannot report it. */
   toolTokens?: number
-  /** Optional in 0.7.2 so 0.7.1 event constructors remain source-compatible. */
+  /** Optional measured detail. Omitted when the adapter cannot report it. */
   toolCallCount?: number
-  /** Optional in 0.7.2 so 0.7.1 event constructors remain source-compatible. */
+  /** Optional measured detail. Omitted when the adapter cannot report it. */
   providerCostUsd?: number
   totalCostUsd: number
   ownerEarnedUsd: number

--- a/tests/a2a-atomicity.test.ts
+++ b/tests/a2a-atomicity.test.ts
@@ -219,7 +219,8 @@ describe('A2A task atomicity and restart recovery', () => {
     }
   })
 
-  it('replays a crashed finalization after restart and clears the lease marker', async () => {
+  it.each([{ tokenAccounting: undefined, complete: true }, { tokenAccounting: 'inclusive', complete: true },
+    { tokenAccounting: undefined, complete: false }] as const)('recovers $tokenAccounting A2A finalization without changing accounting (complete=$complete)', async ({ tokenAccounting, complete }) => {
     const taskStore = new InMemoryTaskStore()
     const counters = { records: 0, settlements: 0 }
     const operations = new MemoryPaymentOperations({
@@ -267,6 +268,7 @@ describe('A2A task atomicity and restart recovery', () => {
         gatewayOrigin: { version: 1, agentId: agent.id, agentSlug: agent.slug },
         gatewayFinalizing: {
           version: 1,
+          ...(tokenAccounting ? { tokenAccounting } : {}),
           lease: { id: 'crashed-lease', expiresAt: Date.now() - 1 },
           agentSlug: agent.slug,
           requestId: 'crashed-request',
@@ -275,7 +277,8 @@ describe('A2A task atomicity and restart recovery', () => {
           startMs: Date.now() - 100,
           operationId: executing.operationId,
           paymentOperation: recoveredOperation(executing),
-          receipt,
+          receipt: { ...receipt, inputTokens: 10, outputTokens: 6,
+            reasoningTokens: complete ? 2 : undefined, toolTokens: complete ? 4 : undefined },
           artifact,
           inputRequired: false,
           maxOutputTokens: 1024,
@@ -322,11 +325,19 @@ describe('A2A task atomicity and restart recovery', () => {
       error?: unknown
     }
 
+    if (!complete) {
+      expect(body.result?.status.state).toBe('working')
+      expect(counters.settlements).toBe(0)
+      expect(operations.get(executing.operationId)?.state).toBe('executing')
+      expect(JSON.stringify((await taskStore.get('task-restart'))?.metadata)).toContain('historical additive accounting requires complete token details')
+      return
+    }
     expect(body.error).toBeUndefined()
     expect(body.result?.status.state).toBe('completed')
     expect(body.result?.artifacts).toEqual([artifact])
     expect((await taskStore.get('task-restart'))?.metadata?.gatewayFinalizing).toBeUndefined()
     expect(operations.get(executing.operationId)?.state).toBe('settled')
+    expect(operations.get(executing.operationId)?.settledAmount).toBe(tokenAccounting === 'inclusive' ? 16n : 22n)
     expect(counters.records).toBe(1)
     expect(counters.settlements).toBe(1)
 

--- a/tests/inclusive-accounting.test.ts
+++ b/tests/inclusive-accounting.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { createAgentGateway } from '../src/middleware'
+import { MemoryPaymentOperations } from '../src/payment-operations'
+import { MemoryPaymentRecoveryStore, serializePaymentOperation } from '../src/payment-recovery'
+import { recoverPayment } from '../src/payment-recovery-worker'
+import type { GatewayConfig, GatewayUsageEvent, SandboxExecutionBudget, SandboxUsageReceipt } from '../src/types'
+
+const agent = { id: 'inclusive', ownerId: 'owner', slug: 'inclusive', enabled: true,
+  pricePerTokenUsd: 0.001, platformFeePercent: 0, sandboxEndpoint: null,
+  remoteSandboxId: null, remoteBearerToken: null }
+const commitment = `0x${'ab'.repeat(32)}`
+const totals: SandboxUsageReceipt = { inputTokens: 10, outputTokens: 6,
+  reasoningTokens: 2, toolTokens: 4, toolCallCount: 1, providerCostUsd: 0.001, budgetEnforced: true }
+
+function fixture(details?: GatewayConfig['executionBudget']) {
+  let received: SandboxExecutionBudget | undefined
+  const settlements: bigint[] = []
+  const usageEvents: GatewayUsageEvent[] = []
+  const recovery = new MemoryPaymentRecoveryStore()
+  const operations = new MemoryPaymentOperations({ onSettle: async (_op, input) => { settlements.push(input.amount) }, onReclaim: async () => {} })
+  const config: GatewayConfig = {
+    resolveAgent: async () => agent, authorizeConsumer: async () => ({ allow: true }),
+    getSandbox: async () => ({ async *streamPrompt(_message, options) {
+      received = options?.executionBudget
+      yield { type: 'usage', data: { usage: totals } }
+    } }), recordUsage: async event => { usageEvents.push(event) },
+    maxOutputTokens: 20, defaultOutputTokens: 20, unauthenticatedInputTokenBound: 100,
+    executionBudget: details,
+    x402: { operatorAddress: '0x1', chainId: 1, demoMode: true,
+      paymentProtocolVersion: 2, paymentOperations: operations },
+    paymentRecovery: { store: recovery, retryDelayMs: 1 },
+  }
+  return { config, recovery, operations, settlements, usageEvents, received: () => received }
+}
+
+async function request(config: GatewayConfig) {
+  const response = await createAgentGateway(config).request('/inclusive/chat/completions', {
+    method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': JSON.stringify({
+      commitment, signature: '0xsig', operator: '0x1', amount: '1000000', nonce: '42',
+      expiry: String(Math.floor(Date.now() / 1000) + 600),
+    }) }, body: JSON.stringify({ stream: false, messages: [{ role: 'user', content: 'test' }] }),
+  })
+  return { status: response.status, text: await response.text() }
+}
+
+describe('inclusive token accounting', () => {
+  it('omits invented detail caps and bills provider totals once through a real payment operation', async () => {
+    const f = fixture()
+    expect((await request(f.config)).status).toBe(200)
+    expect(f.received()).not.toHaveProperty('maxReasoningTokens')
+    expect(f.received()).not.toHaveProperty('maxToolTokens')
+    expect(f.received()?.maxProviderCostUsd).toBe(0.12)
+    expect(f.settlements).toEqual([16000n])
+    expect(f.usageEvents[0]?.totalCostUsd).toBe(0.016)
+    const record = await f.recovery.get(`x402:${commitment}:42`)
+    expect(record?.attribution.tokenAccounting).toBe('inclusive')
+    expect(record?.attribution.requiredAmount).toBe('120000')
+  })
+
+  it('preserves and enforces explicitly supplied detail caps, including zero', async () => {
+    for (const details of [{ maxReasoningTokens: 0 }, { maxToolTokens: 0 }]) {
+      const f = fixture(details)
+      const response = await request(f.config)
+      expect(response.status).toBe(500)
+      expect(response.text).toMatch(/max reasoning|max tool/)
+      expect(f.received()).toMatchObject(details)
+      expect(f.settlements).toEqual([])
+    }
+  })
+
+  it('accepts an inclusive receipt without unmeasured detail fields and rejects it under explicit caps', async () => {
+    for (const explicit of [false, true]) {
+      const f = fixture(explicit ? { maxReasoningTokens: 10 } : undefined)
+      f.config.getSandbox = async () => ({ async *streamPrompt() {
+        yield { type: 'usage', data: { usage: { inputTokens: 10, outputTokens: 6,
+          toolCallCount: 1, providerCostUsd: 0.001, budgetEnforced: true } } }
+      } })
+      const response = await request(f.config)
+      expect(response.status, response.text).toBe(explicit ? 500 : 200)
+      if (explicit) expect(response.text).toContain('explicit token cap')
+    }
+  })
+
+  it.each([{ tokenAccounting: undefined, complete: true }, { tokenAccounting: 'inclusive', complete: true },
+    { tokenAccounting: undefined, complete: false }] as const)('keeps persisted $tokenAccounting recovery accounting stable (complete=$complete)', async ({ tokenAccounting, complete }) => {
+    const f = fixture()
+    const amounts: bigint[] = []
+    const operations = new MemoryPaymentOperations({ onSettle: async (_operation, input) => {
+      amounts.push(input.amount)
+      throw new Error('acknowledgement lost')
+    }, onReclaim: async () => {} })
+    f.config.x402.paymentOperations = operations
+    const budget = { maxInputTokens: 100, maxOutputTokens: 20, maxToolCalls: 8, maxProviderCostUsd: 1 }
+    const claimed = await operations.claimPayment({ commitment, nonce: '43', amount: '1000000',
+      expiry: String(Math.floor(Date.now() / 1000) + 600) },
+    { requestId: 'historical', agentId: agent.id, requiredAmount: 100000n, maxOutputTokens: 20, executionBudget: budget })
+    const executing = await operations.beginPaymentExecution(claimed)
+    const now = Date.now()
+    await f.recovery.createIfAbsent({ version: 1, id: executing.operationId, revision: 0, state: 'settling',
+      payment: { kind: 'x402', operationId: executing.operationId, operation: serializePaymentOperation(executing) },
+      attribution: { ...(tokenAccounting ? { tokenAccounting } : {}), requestId: 'historical', agentId: agent.id,
+        agentSlug: agent.slug, consumerId: commitment, paymentMethod: 'x402', startMs: now,
+        pricePerTokenUsd: agent.pricePerTokenUsd, platformFeePercent: 0, requiredAmount: '100000',
+        currencyDecimals: 6, maxOutputTokens: 20, executionBudget: budget },
+      workStarted: true, usage: complete ? totals : { inputTokens: 10, outputTokens: 6, toolCallCount: 1, providerCostUsd: 0.001, budgetEnforced: true }, usageRecorded: false, attempts: 0, nextAttemptAt: now, createdAt: now, updatedAt: now })
+    if (!complete) {
+      await expect(recoverPayment(executing.operationId, f.config, { force: true })).rejects.toThrow('historical additive accounting requires complete token details')
+      expect(amounts).toEqual([])
+      expect(operations.get(executing.operationId)?.state).toBe('executing')
+      return
+    }
+    await expect(recoverPayment(executing.operationId, f.config, { force: true })).rejects.toThrow('acknowledgement lost')
+    const expected = tokenAccounting === 'inclusive' ? 16000n : 22000n
+    expect(amounts).toEqual([expected])
+    expect((await recoverPayment(executing.operationId, f.config, { force: true }))?.state).toBe('reconciled')
+    expect(operations.get(executing.operationId)?.settledAmount).toBe(expected)
+    await recoverPayment(executing.operationId, f.config, { force: true })
+    expect(amounts).toEqual([expected])
+  })
+})

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -604,7 +604,7 @@ describe('POST /:slug/chat/completions — auth paths', () => {
     const body = await res.json() as { error: { payment_methods: string[]; x402: Record<string, unknown> } }
     expect(body.error.payment_methods).toContain('x402')
     expect(body.error.x402.operator).toBe(operatorAddress)
-    expect(body.error.x402.required_amount).toBe('185460')
+    expect(body.error.x402.required_amount).toBe('21620')
     expect(body.error.x402.max_output_tokens).toBe(1024)
   })
 

--- a/tests/payment-operations.test.ts
+++ b/tests/payment-operations.test.ts
@@ -438,8 +438,6 @@ describe('bounded request pricing and sandbox receipts', () => {
     await expect(collectUsage([partialUsageEvent()])).resolves.toEqual({
       inputTokens: 40,
       outputTokens: 20,
-      reasoningTokens: 0,
-      toolTokens: 0,
       toolCallCount: 0,
       providerCostUsd: 0.0123,
       budgetEnforced: false,


### PR DESCRIPTION
Input and output usage now represent inclusive provider totals, so reasoning and tool details are not charged twice.
The gateway omits separate detail caps unless the host explicitly supplies them; explicit caps, including zero, still require measured usage and enforcement.
New quotes use inclusive totals and the provider-cost ceiling.

Historical payment outbox and A2A finalization records retain their original additive accounting and settlement amounts.
New records persist an inclusive accounting basis.
Incomplete historical receipts fail rather than substituting zero for missing details.
The README documents the 0.11.0 adapter migration and historical-record constraints.

Validation: 488 tests pass under Node 24.18.0 and 22.22.2; typecheck and build pass.
Real payment/recovery fixtures cover inclusive settlement, explicit caps, omitted details, acknowledgement loss, repeated recovery, and incomplete historical receipts.
Three deliberate mutations fail: invented detail caps, reinterpretation of historical accounting, and double billing of detail counts.
