### PR TITLE
fix(gateway): reconcile enforced receipts from failed executions

### DIFF
--- a/.agent/harden/2026-09-08-report.md
+++ b/.agent/harden/2026-09-08-report.md
@@ -1,0 +1,24 @@
+# Failed execution receipt accounting
+
+Boundary: maintained Runtime producer → persisted chat route → gateway stream → payment settlement and recovery.
+A terminal sandbox error previously discarded measured usage already received by dispatch.
+Failed calls retained quoted payment ownership instead of reconciling their authoritative receipt.
+
+The gateway now validates and yields the enforced receipt before raising the terminal protocol error.
+Only this protocol error carries failed-run usage into settlement.
+Settlement stores the receipt before external payment effects.
+A2A clears only reconciled payment markers and preserves failed task status.
+Missing or unenforced receipts retain ownership; the configured recovery policy still applies.
+
+Regression coverage uses synthetic identities and callbacks, real Runtime execution, SQL API-key stores, and maintained payment operations.
+JSON and SSE settle actual usage while returning errors.
+Both A2A methods preserve failed tasks after reconciliation.
+Lost settlement acknowledgements recover the measured amount once.
+SQL keys charge 2 cents against a 10-cent quote and permit the remaining 18 cents of a 20-cent cap.
+The composed SDK test performs one synthetic inference and one failing tool, then charges 5000 units against a 1100000-unit quote.
+Removing the pre-error usage handoff fails both focused and composed regressions.
+
+Evidence: `/tmp/gateway-failed-final-{all,node22,typecheck,build}.log`, `/tmp/gateway-composed-registry.log`, `/tmp/gateway-composed-mutation.json`, `/tmp/gateway-failed-receipt-mutation.json`.
+The composed regression uses published agent-app 0.47.6 and Runtime 0.192.2.
+All fixtures use isolated memory/SQLite state; SQLite handles close after tests.
+These tests do not establish external payment transfer or live provider enforcement.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,12 @@ New payment outbox and A2A finalization records store `tokenAccounting: 'inclusi
 Historical records without that field retain additive settlement arithmetic during recovery.
 Do not backfill the marker onto historical pending operations or replace their original quoted amounts.
 Requests with a version 2 operation or generic MPP charge reject missing receipts.
-API-key requests keep the legacy visible-token estimate path.
+Uncapped API-key requests keep the legacy visible-token estimate path on successful completion.
+Capped requests require enforced usage receipts.
+A failed run must emit its complete, enforced receipt before `error` or `session.run.failed`.
+The gateway settles that measured usage while preserving the failed response or task state.
+Missing, invalid, or unenforced failed-run receipts never become estimated usage charges.
+Payment recovery retains unresolved ownership under its configured recovery policy.
 recordUsage must atomically upsert by event.requestId; recovery may retry an event after its acknowledgement is lost.
 Explicit demo mode exposes A2A with an in-memory task store.
 Production must configure an atomic durable task store; otherwise A2A returns `503` while the OpenAI surface remains available.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangle-network/agent-gateway",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "packageManager": "pnpm@10.28.0",
   "engines": {
     "node": ">=22.13.0"
@@ -45,13 +45,17 @@
     "hono": "^4.13.5"
   },
   "devDependencies": {
+    "@tangle-network/agent-app": "0.47.6",
+    "@tangle-network/agent-interface": "2.3.0",
+    "@tangle-network/agent-runtime": "0.192.2",
+    "@tangle-network/sandbox": "0.37.0",
     "@types/node": "^24.13.3",
     "@vitest/coverage-v8": "^4.1.11",
     "tsup": "^8.0.0",
     "typescript": "^5.9.3",
     "viem": "^2.56.2",
-    "vitest": "^4.1.11",
-    "vite": "8.0.16"
+    "vite": "8.0.16",
+    "vitest": "^4.1.11"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,18 @@ importers:
         specifier: 4.13.5
         version: 4.13.5
     devDependencies:
+      '@tangle-network/agent-app':
+        specifier: 0.47.6
+        version: 0.47.6(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-integrations@0.53.55(@types/node@24.13.3))(@tangle-network/agent-interface@2.3.0)(@tangle-network/agent-knowledge@13.0.1(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-interface@2.3.0))(@tangle-network/agent-profile-materialize@0.19.2(@tangle-network/agent-interface@2.3.0))(@tangle-network/agent-runtime@0.192.2(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-interface@2.3.0)(@tangle-network/sandbox@0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4))))(@tangle-network/sandbox@0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4)))
+      '@tangle-network/agent-interface':
+        specifier: 2.3.0
+        version: 2.3.0
+      '@tangle-network/agent-runtime':
+        specifier: 0.192.2
+        version: 0.192.2(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-interface@2.3.0)(@tangle-network/sandbox@0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4)))
+      '@tangle-network/sandbox':
+        specifier: 0.37.0
+        version: 0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4))
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -27,24 +39,29 @@ importers:
         version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.23)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.23)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       viem:
         specifier: ^2.56.2
-        version: 2.56.2(typescript@5.9.3)
+        version: 2.56.2(typescript@5.9.3)(zod@4.5.4)
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)
+        version: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1))
+        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))
 
 packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@asteasolutions/zod-to-openapi@9.1.0':
+    resolution: {integrity: sha512-pLMeRgRYS7/vZIgAAkOe2P6+XGTifR1MT9pqDoxZ11EmcJJ+DPmdPqLN8ZZF4U8R9KHCCQCS9c2wtuE8wSrfkw==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -66,6 +83,52 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@duckdb/node-api@1.5.5-r.2':
+    resolution: {integrity: sha512-PhpjvblIQV36IlnWGOWcLCVhCBPALJ+gu2d4MR5VIveVS57Bx1Hpvoe9BZqPcMzMeqWc3sQOpcr8DoZ/hKB2PQ==}
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.5-r.2':
+    resolution: {integrity: sha512-huZfnM/awM62hpPlK7ckx0u0twW3zc00Bs0qfY8ldhjwVn+Jf764pxFdMmUujYWtMdsSZIk4FvMy8ZQijALOPg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-darwin-x64@1.5.5-r.2':
+    resolution: {integrity: sha512-/TlqNBOqg2EbBJ2MjVDkJg6IKQHE1SkCC41cn4e5CaJVxj7re1A77W6o1V7Xa/25jftO1HxvGBlHGP15dmjMxQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-linux-arm64-musl@1.5.5-r.2':
+    resolution: {integrity: sha512-78lhr3GBzscZXA3iHqOIIo5+zRbtSA+lNHUBHZPLUICn0+boeGic4JP/KE3Y2MTNAe4OqG4ctfl8CX1tBArjQA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@duckdb/node-bindings-linux-arm64@1.5.5-r.2':
+    resolution: {integrity: sha512-hlyuOvjOShhgsTguCGv9A6M5QZf9NiFW/fmq9aZO7lhlz0P0cBVOiCca+CAhcnePrbZmzeGZ21fwiBs6T12StA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@duckdb/node-bindings-linux-x64-musl@1.5.5-r.2':
+    resolution: {integrity: sha512-eKvMBSEyd3Vq4CiPGTXAb4Ww+l9XPuTR3WzXbHQMwJjEEGbnFhnHaqjtLyr3Chqg0iDWe41empP3IC7XWPBpiQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@duckdb/node-bindings-linux-x64@1.5.5-r.2':
+    resolution: {integrity: sha512-e8SypIiYX3wzvB2CfEr3zTfoCOqkqt0zvcc025ukVno95W+hnH37NJOEdhC7RfSCEwgaPrkWGChhZ3x3EVZsTg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@duckdb/node-bindings-win32-arm64@1.5.5-r.2':
+    resolution: {integrity: sha512-87wuGkEjc4VwcDZI09rSm6FXc8F9oHZWYE7so8p2l4qtmGCfsoLwSSlnhi9MHGefGqUBxshfJ0O9Zvg7A0//ag==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@duckdb/node-bindings-win32-x64@1.5.5-r.2':
+    resolution: {integrity: sha512-r5V6Q0zcv5HSHGDXsd6M+t3jakhm6S11TNH5vydKGeq8JBWj4v3ZTof/mF3R8Rly+90Z205KoI9ujblg/jN04g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@duckdb/node-bindings@1.5.5-r.2':
+    resolution: {integrity: sha512-sdLrfvfOxhFA6igCMiToaYSYaffd7D5j00ooy7Y1ACJ1PZKTVENwHV91RfECyNrlGGZItNbfqVR/yHL1jiHMcQ==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -232,6 +295,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: 4.13.5
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -244,6 +313,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mongodb-js/saslprep@1.5.2':
+    resolution: {integrity: sha512-UBvCBdPHAmiiDNEpD2ORBGzna4qYr06fLELfGDPW3/KZ9uLK+cGT9npAc/x/6/8SLzdbILMuc3HWFQ0FvJMhCw==}
 
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
@@ -264,8 +336,48 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@2.4.0':
+    resolution: {integrity: sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==}
+    engines: {node: '>= 20.19.0'}
+
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@redis/bloom@6.1.0':
+    resolution: {integrity: sha512-Rzascjd9J9bJsM45T/Z9CTg1QY/B63B6YO8QorLVMeXnbBDsKiSCVR/+GQ061hYPk8FpTzWmPY8tAv2sT+JEtQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.1.0
+
+  '@redis/client@6.1.0':
+    resolution: {integrity: sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@6.1.0':
+    resolution: {integrity: sha512-/GFjQA6bu5pG9ClCJAI5Xx4bNXe7UTpxBBlIupBNTrn1+nY860apGnYJuaSCDV2BmEbTidpa7O2qa28oxKx+rg==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.1.0
+
+  '@redis/search@6.1.0':
+    resolution: {integrity: sha512-kS5agg+3yZbrdrt8omrew7FLCD8eOm7tarG1CROekPBRe+QGDR9aOpnHIQaYsYi6wPRTH70nQiF06AIjgURefQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.1.0
+
+  '@redis/time-series@6.1.0':
+    resolution: {integrity: sha512-uIDBtV8MmG/xpJsRqbGSO4iX6ryj37MLMP82lRpFvI7ykAVe5GyqgxigEbU+uZNv9kDPNMKw3dvI/S/J1BNBzA==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.1.0
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -496,6 +608,161 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tangle-network/agent-app@0.47.6':
+    resolution: {integrity: sha512-do++0y9wsLITFumUMdBW0vMT3HTS9TKfPrQgwk0M8ST3pf3UAUcnWm9QUf0s36Hku8UCyUpTeffMaeF0F+VxLg==}
+    hasBin: true
+    peerDependencies:
+      '@firecrawl/pdf-inspector-wasm': '>=0.1.3'
+      '@huggingface/transformers': '>=3'
+      '@tangle-network/agent-eval': '>=0.173.1 <0.174.0'
+      '@tangle-network/agent-integrations': '>=0.53.55 <0.54.0'
+      '@tangle-network/agent-interface': ^2.3.0
+      '@tangle-network/agent-knowledge': ^13.0.1
+      '@tangle-network/agent-profile-materialize': '>=0.19.0 <0.20.0'
+      '@tangle-network/agent-runtime': '>=0.191.0 <0.193.0'
+      '@tangle-network/brand': '>=1.5.0'
+      '@tangle-network/sandbox': '>=0.36.4 <0.38.0'
+      '@tangle-network/sandbox-ui': '>=0.113.3 <0.114.0'
+      '@tangle-network/ui': '>=11.6.0 <12.0.0'
+      '@tiptap/core': '>=3.28.0 <4.0.0'
+      '@tiptap/extension-mention': '>=3.28.0 <4.0.0'
+      '@tiptap/pm': '>=3.28.0 <4.0.0'
+      '@tiptap/react': '>=3.28.0 <4.0.0'
+      '@tiptap/starter-kit': '>=3.28.0 <4.0.0'
+      '@tiptap/suggestion': '>=3.28.0 <4.0.0'
+      '@xyflow/react': '>=12.0.0'
+      better-auth: '>=1.6.16'
+      drizzle-orm: '>=0.36'
+      konva: '>=9'
+      lucide-react: '>=1'
+      pdf-lib: '>=1.17'
+      react: '>=18'
+      react-dom: '>=18'
+      react-konva: '>=18'
+      react-router: '>=8.3.0'
+      resend: '>=6'
+    peerDependenciesMeta:
+      '@firecrawl/pdf-inspector-wasm':
+        optional: true
+      '@huggingface/transformers':
+        optional: true
+      '@tangle-network/agent-knowledge':
+        optional: true
+      '@tangle-network/agent-profile-materialize':
+        optional: true
+      '@tangle-network/agent-runtime':
+        optional: true
+      '@tangle-network/brand':
+        optional: true
+      '@tangle-network/sandbox':
+        optional: true
+      '@tangle-network/sandbox-ui':
+        optional: true
+      '@tangle-network/ui':
+        optional: true
+      '@tiptap/core':
+        optional: true
+      '@tiptap/extension-mention':
+        optional: true
+      '@tiptap/pm':
+        optional: true
+      '@tiptap/react':
+        optional: true
+      '@tiptap/starter-kit':
+        optional: true
+      '@tiptap/suggestion':
+        optional: true
+      '@xyflow/react':
+        optional: true
+      better-auth:
+        optional: true
+      drizzle-orm:
+        optional: true
+      konva:
+        optional: true
+      lucide-react:
+        optional: true
+      pdf-lib:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      react-konva:
+        optional: true
+      react-router:
+        optional: true
+      resend:
+        optional: true
+
+  '@tangle-network/agent-core@0.9.6':
+    resolution: {integrity: sha512-vTVSIsYUDfcgJ0mdhPXZRvP9NrBXdiuHu/RE2JReSZoJcWJHfElDcpaEgxYmSNrJ6DV3scT/+VyrMT+aHDvoaA==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.30.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
+  '@tangle-network/agent-eval@0.173.3':
+    resolution: {integrity: sha512-xP3hHhhnNxijF0V9d+kK+98ZAKjgtm0/g9muYeUQG6wXuaD0klOL976HOZApeqsHjlvLgpKO8VdhxOBxyRX6EA==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
+  '@tangle-network/agent-integrations@0.53.55':
+    resolution: {integrity: sha512-UvNBTo3D2SUOaLeG7rpHyl23cAXItYJjr5uHuE2XogA2/D378Y0RJmtpRczmAEaBbVIsaQqxR9RaOjzkYz3BJw==}
+    engines: {node: '>=20'}
+
+  '@tangle-network/agent-interface@2.3.0':
+    resolution: {integrity: sha512-4BLA6WIgbK9ZtqWD8+sQvMjAMLhT2yDvRQwN/aH3KaWLe2SQ8aXT6B1+VmunM8rvWd6Q9iFvTGOx/l8TXjKtLA==}
+
+  '@tangle-network/agent-interface@2.6.0':
+    resolution: {integrity: sha512-tEByATif9oM5EEQB94Fytjt1Jtd70KxbWudKpwMQYyqXw2dcVFh2JTkeE8rIQP2F8KDLj9n5VHFkwg/ikbr7dg==}
+
+  '@tangle-network/agent-knowledge@13.0.1':
+    resolution: {integrity: sha512-G0y4M83ov1S5N0xWdVOWPhydzm8BEZ8lfuanwe7vGbtSKlzKMZKP6tYIUiff8neWbBNubx8fRS82vlE72Ev5bQ==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      '@tangle-network/agent-eval': '>=0.173.0 <0.174.0'
+      '@tangle-network/agent-interface': ^2.0.0
+
+  '@tangle-network/agent-profile-materialize@0.19.2':
+    resolution: {integrity: sha512-kATZeW2oSf8PCt/h1AyxE/pIl4g/2uVdWR7clGPeMzt97m/EpaknnjGi1FTJUAgNM2K7flqa9r/H2F0/6nQAMw==}
+    peerDependencies:
+      '@tangle-network/agent-interface': ^1.0.0 || ^2.0.0
+
+  '@tangle-network/agent-runtime@0.192.2':
+    resolution: {integrity: sha512-WEoDn72EVFJ41cQP8Cb65bz0VpyC5TkxvGzgFeEO1Hq6i/FqgI2uaLc2RlnXhLfbi5FUGKgc8LX72iIYkhL4LA==}
+    engines: {node: '>=22.13.0'}
+    hasBin: true
+    peerDependencies:
+      '@tangle-network/agent-eval': '>=0.173.0 <0.174.0'
+      '@tangle-network/agent-interface': ^2.3.0
+      '@tangle-network/sandbox': '>=0.36.4 <0.38.0'
+
+  '@tangle-network/agent-trace-contract@1.0.2':
+    resolution: {integrity: sha512-v7uMh56jkEp4vckevEU9xKsIatbs5dqzGPp69dFLSSXUVit0RP6VD6EANMXVlTCUk+6wVKBLHJx23XspVCEiIA==}
+
+  '@tangle-network/sandbox@0.37.0':
+    resolution: {integrity: sha512-x++Fce8uRCehFrHsAOHzqIJaKNmIL7R5wMhjR7dTXNcOt/FxX9BCEpy5Lkhwp7jMRsjjgSAVcKMpsKMyBRZBWQ==}
+    peerDependencies:
+      '@mastra/core': ^1.36.0
+      '@modelcontextprotocol/sdk': ^1.30.0
+      ai: ^6.0.175
+      openai: ^6.36.0
+      viem: ^2.0.0
+    peerDependenciesMeta:
+      '@mastra/core':
+        optional: true
+      '@modelcontextprotocol/sdk':
+        optional: true
+      ai:
+        optional: true
+      openai:
+        optional: true
+      viem:
+        optional: true
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -510,6 +777,18 @@ packages:
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
+
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@11.0.5':
+    resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
 
   '@vitest/coverage-v8@4.1.11':
     resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
@@ -565,8 +844,15 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  amqplib@2.0.1:
+    resolution: {integrity: sha512-a3P2MgfCf9nzVis12VxWEn0dS6hcqve7dlEAhXDtIWR27BlhtMkILOc+H9aeHjDi6i6r94dYKc2Kx2OFe3avvg==}
+    engines: {node: '>=18'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -574,6 +860,72 @@ packages:
 
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  bare-events@2.9.2:
+    resolution: {integrity: sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.8.1:
+    resolution: {integrity: sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==}
+    engines: {bare: '>=1.28.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.2:
+    resolution: {integrity: sha512-ZyKbsuuqK6Ag0K8pX6V5Txq6XeJRvY+wXucnFGRjiyVYP9YWDpIQugk/b+enRYrEYBJaqLzghRQpXPMR7341Nw==}
+
+  bare-stream@2.13.4:
+    resolution: {integrity: sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.5.4:
+    resolution: {integrity: sha512-Gxa7UVWBr0/edU1b+TJhn/AZvMQUj9OGspvYsaTYQrAbZA4BOTZGL3LiZxvD+CeMlDH4juwD84+eTAp/bLYW5g==}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  binary-search@1.3.6:
+    resolution: {integrity: sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==}
+
+  bson@6.10.4:
+    resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
+    engines: {node: '>=16.20.1'}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -589,13 +941,24 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  cheminfo-types@1.15.0:
+    resolution: {integrity: sha512-shv45WN2u0yN9EHH1bisNrv+fy4Cw+eLM5lOoriP67mePrwbHZ1kJqg90C8GEU7K1A8gJsicEoVZHcuBbuul/w==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -607,6 +970,16 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
+
+  csv-parse@7.0.1:
+    resolution: {integrity: sha512-+2z7Ar0APQ7Uu6fX4cn+pitRmxjZ1WPBcGmZFKmA74FCyi7Et/XZx8cjNQ5CjbZ4HCOxXCOpRBYvYH08Qa003A==}
+
+  csv-stringify@6.8.1:
+    resolution: {integrity: sha512-tZ6X6TKQyQgCo5OptXcyAbfN1pwmoxEqELPQ7KFazNErx7kiVsDK8o+VYRXhfMl4N9vvOOLXuioquR2MeP847A==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -615,6 +988,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -634,9 +1011,15 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -647,6 +1030,12 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
+  fft.js@4.0.4:
+    resolution: {integrity: sha512-f9c00hphOgeQTlDyavwTtu6RiK8AIFjD6+jvXkNkpeQ7rirK3uFWVpalkoS4LAwbdX7mfZ8aoBfFVQX1Re/8aw==}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
@@ -654,6 +1043,12 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -665,6 +1060,32 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  hyparquet-writer@0.16.1:
+    resolution: {integrity: sha512-vb87T2ub06kbEKZOQoHTbVwN0kXQPM5mnMuyTNqQPsOzf85qYBzyFG6R83CnXNhrlncdpRtXeKrbF3ZoLj26pg==}
+
+  hyparquet@1.26.1:
+    resolution: {integrity: sha512-Me2psKksCqJGR8+TbalUYUyK4Ao+ReA6XmMSiOVPhOBswULbl3ojT06PQajyTafbNPW1vD0tCA7H6dXJAC1TPw==}
+
+  hyparquet@1.27.1:
+    resolution: {integrity: sha512-kvMGVKlB/xa9UHxWLJkySJYGC436nPeBWC9Fzo/BZtMEzFUjmzD1KuLz67EOpA3Ci6V7yF/yTG7QRSDSx5EDSg==}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
+
+  is-any-array@3.0.0:
+    resolution: {integrity: sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww==}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
@@ -683,12 +1104,19 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jose@6.2.4:
+    resolution: {integrity: sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  kafkajs@2.2.4:
+    resolution: {integrity: sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==}
+    engines: {node: '>=14.0.0'}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -764,12 +1192,22 @@ packages:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
+  linear-sum-assignment@1.0.9:
+    resolution: {integrity: sha512-1T2Ek3sxpt2mBHeBFMRJEikiIK/yIOwf+mrxv/DkAU/5ddnCMndZL//hFH7QuHa1tbaQADzsf9t7rkGZKqoFfQ==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru.min@1.1.5:
+    resolution: {integrity: sha512-5J9ysMYUpYIg9RF2vJpy9SinEmSviFSe0GyPpCQ4L5QSkLAgeLXlTAOu2ZwWUU5m+0SBl6gUU1R1ZQB3aKypfA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -781,19 +1219,86 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
+  ml-array-max@2.0.0:
+    resolution: {integrity: sha512-QQZ4kENwpWmyNb98UXRDFXrmtIXuXtt1+bSbda/2KA85+F+rrJP8hZk6QOkCQXM2Th9mUDYdq/PNByPdT9ID4A==}
+
+  ml-array-min@2.0.0:
+    resolution: {integrity: sha512-GRj6Ky6sW9vGL6yIjgsHmXZ9YgrdmcQ8nCxPqEGeKc6dkfYg1XDYxGFxADUjNuZyoCd5PUscWAS4N+cFaX6hFg==}
+
+  ml-array-rescale@2.0.0:
+    resolution: {integrity: sha512-2GGtKfSno94/kIloWGvpp/U5Q5vLvLrza+SAaGsLeo6Xj4mEbA6Gqx+oTfZFkxnd1grT2X007HfJNs3T5BsiVg==}
+
+  ml-matrix@6.15.0:
+    resolution: {integrity: sha512-wFa1v6KP8bKp+fj0nYmRs1Pb5K4zRkXGKsOvLinvILENFIADncm4XlOI+S1M7yuACMGfI6cfk0IifDgd4j5xmw==}
+
+  ml-spectra-processing@14.34.0:
+    resolution: {integrity: sha512-sNM3nOg7s4tyinRnU5FyYZFV//cPHMvjwfxQvFh3GyrvWNuZmPIZTPS+kiT/SPXMymxA4+qx8oFSZ9K03clGyQ==}
+
+  ml-xsadd@3.0.1:
+    resolution: {integrity: sha512-Fz2q6dwgzGM8wYKGArTUTZDGa4lQFA2Vi6orjGeTVRy22ZnQFKlJuwS9n8NRviqz1KHAHAzdKJwbnYhdo38uYg==}
+
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  mongodb-connection-string-url@3.0.2:
+    resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
+
+  mongodb@6.21.0:
+    resolution: {integrity: sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==}
+    engines: {node: '>=16.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
+      snappy: ^7.3.2
+      socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mysql2@3.23.2:
+    resolution: {integrity: sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==}
+    engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
+
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -801,6 +1306,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  openapi3-ts@4.6.1:
+    resolution: {integrity: sha512-XW9MOldkhoICNeXVzzmXzmOW5G73ppOEGmh7fLCqHjgfdEYCGGN+00MlVCeUZgovjjfC56j9tvtDt1zGabNjjA==}
 
   ox@0.14.44:
     resolution: {integrity: sha512-O54qXXHEk4ySamMSyBpI0AeBegS5frxU6+LA6Jb9Sf6kMOxcTNaxYmwZfpOu22DIQsdKfgQxHq8EsAGaoBQScA==}
@@ -812,6 +1320,40 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -853,13 +1395,56 @@ packages:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  re2js@2.8.6:
+    resolution: {integrity: sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==}
+    engines: {node: '>=18.0.0'}
+
+  read-excel-file@9.3.5:
+    resolution: {integrity: sha512-A4EbaJxFrqzBNdU4Lw0g6wzme3m7ywW3MsPLLuBiGPUWJbxETyVDT5vyqsOnl/AW48OGM4MGoOgKFsEZNMMVVw==}
+    engines: {node: '>=18'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redis@6.1.0:
+    resolution: {integrity: sha512-0kvUPM8RHP/ZMa0xYaDTcG5e8tIGW6kz6MToVT0V8iOnk6bkXp2jncGRGe2bZEk41lZwiDspUqjZCSk5ohjcKw==}
+    engines: {node: '>= 20.0.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
@@ -871,6 +1456,16 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxen@11.1.1:
+    resolution: {integrity: sha512-J4BkmJFaM7VgE7pgkFGsNEcqqM3h7+Mz80vfLWFhx7uNOCOXIu6LLjQHYWNejdst3pf/3JUaBIG9+pkk1umlow==}
+    engines: {node: '>= 20.12'}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -878,6 +1473,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -887,11 +1485,45 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@5.0.0:
+    resolution: {integrity: sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  sql-escaper@1.5.1:
+    resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
+
+  ssh2-sftp-client@12.1.1:
+    resolution: {integrity: sha512-wYVDgwkpcKG2iPGQQ+QR33xkWqLFIaVrYvA+uON4pmxTPaPuB81f1aooUEPN75e/9DCK6rrKYXb6zR6zP3+EtA==}
+    engines: {node: '>=18.20.4'}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  streamx@2.28.1:
+    resolution: {integrity: sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -901,6 +1533,15 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tar-stream@3.2.1:
+    resolution: {integrity: sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -931,6 +1572,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -960,6 +1605,12 @@ packages:
       typescript:
         optional: true
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -970,6 +1621,13 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unzipper-esm@0.13.3:
+    resolution: {integrity: sha512-LUO6VZ6fCzkDbdMev0/fOhoIeVGKaOkTIOoYxVLE0SQjfvmAHK+oywl7lfhloSZIsdGJ25mJ18Mtd9CyTASjrA==}
+    engines: {node: '>=8.0.0'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   viem@2.56.2:
     resolution: {integrity: sha512-AZuagzVlDAB93I68Jh9jwdaR9cGlkpDSYR13RYwmSTtTmagBjqu+ApYii4mUtWHLkZDJ85pGYAOzZZaSLDrigQ==}
@@ -1063,10 +1721,26 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  worker-f@0.1.20:
+    resolution: {integrity: sha512-7z5K5z4x++FykhpDTfriT/dOu7CmSap9BBv38DVFU3CD38obopq+DoFH75yBV3butpGm+OeqR9BKdSvYJSnUfQ==}
+    engines: {node: '>=12'}
+
+  write-excel-file@4.1.1:
+    resolution: {integrity: sha512-MUnCnNtQrcZek832ZcU24uU0rSphFmKPD1DvIjXOlygVb93CV7Tme6H3jUTkxsMmjB2W7HIzERzjqTi5kui71A==}
+    engines: {node: '>=18'}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -1080,9 +1754,29 @@ packages:
       utf-8-validate:
         optional: true
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
+
 snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
+
+  '@asteasolutions/zod-to-openapi@9.1.0(zod@4.5.4)':
+    dependencies:
+      openapi3-ts: 4.6.1
+      zod: 4.5.4
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -1098,6 +1792,47 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@duckdb/node-api@1.5.5-r.2':
+    dependencies:
+      '@duckdb/node-bindings': 1.5.5-r.2
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.5-r.2':
+    optional: true
+
+  '@duckdb/node-bindings-darwin-x64@1.5.5-r.2':
+    optional: true
+
+  '@duckdb/node-bindings-linux-arm64-musl@1.5.5-r.2':
+    optional: true
+
+  '@duckdb/node-bindings-linux-arm64@1.5.5-r.2':
+    optional: true
+
+  '@duckdb/node-bindings-linux-x64-musl@1.5.5-r.2':
+    optional: true
+
+  '@duckdb/node-bindings-linux-x64@1.5.5-r.2':
+    optional: true
+
+  '@duckdb/node-bindings-win32-arm64@1.5.5-r.2':
+    optional: true
+
+  '@duckdb/node-bindings-win32-x64@1.5.5-r.2':
+    optional: true
+
+  '@duckdb/node-bindings@1.5.5-r.2':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@duckdb/node-bindings-darwin-arm64': 1.5.5-r.2
+      '@duckdb/node-bindings-darwin-x64': 1.5.5-r.2
+      '@duckdb/node-bindings-linux-arm64': 1.5.5-r.2
+      '@duckdb/node-bindings-linux-arm64-musl': 1.5.5-r.2
+      '@duckdb/node-bindings-linux-x64': 1.5.5-r.2
+      '@duckdb/node-bindings-linux-x64-musl': 1.5.5-r.2
+      '@duckdb/node-bindings-win32-arm64': 1.5.5-r.2
+      '@duckdb/node-bindings-win32-x64': 1.5.5-r.2
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -1193,6 +1928,10 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@hono/node-server@2.1.1(hono@4.13.5)':
+    dependencies:
+      hono: 4.13.5
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1206,6 +1945,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mongodb-js/saslprep@1.5.2':
+    dependencies:
+      sparse-bitfield: 3.0.3
 
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -1222,7 +1965,29 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@noble/hashes@2.4.0': {}
+
   '@oxc-project/types@0.133.0': {}
+
+  '@redis/bloom@6.1.0(@redis/client@6.1.0)':
+    dependencies:
+      '@redis/client': 6.1.0
+
+  '@redis/client@6.1.0':
+    dependencies:
+      cluster-key-slot: 1.1.2
+
+  '@redis/json@6.1.0(@redis/client@6.1.0)':
+    dependencies:
+      '@redis/client': 6.1.0
+
+  '@redis/search@6.1.0(@redis/client@6.1.0)':
+    dependencies:
+      '@redis/client': 6.1.0
+
+  '@redis/time-series@6.1.0(@redis/client@6.1.0)':
+    dependencies:
+      '@redis/client': 6.1.0
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -1365,6 +2130,118 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tangle-network/agent-app@0.47.6(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-integrations@0.53.55(@types/node@24.13.3))(@tangle-network/agent-interface@2.3.0)(@tangle-network/agent-knowledge@13.0.1(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-interface@2.3.0))(@tangle-network/agent-profile-materialize@0.19.2(@tangle-network/agent-interface@2.3.0))(@tangle-network/agent-runtime@0.192.2(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-interface@2.3.0)(@tangle-network/sandbox@0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4))))(@tangle-network/sandbox@0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4)))':
+    dependencies:
+      '@tangle-network/agent-eval': 0.173.3
+      '@tangle-network/agent-integrations': 0.53.55(@types/node@24.13.3)
+      '@tangle-network/agent-interface': 2.3.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@tangle-network/agent-knowledge': 13.0.1(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-interface@2.3.0)
+      '@tangle-network/agent-profile-materialize': 0.19.2(@tangle-network/agent-interface@2.3.0)
+      '@tangle-network/agent-runtime': 0.192.2(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-interface@2.3.0)(@tangle-network/sandbox@0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4)))
+      '@tangle-network/sandbox': 0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4))
+
+  '@tangle-network/agent-core@0.9.6':
+    dependencies:
+      '@tangle-network/agent-interface': 2.3.0
+      zod: 4.5.4
+
+  '@tangle-network/agent-eval@0.173.3':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 9.1.0(zod@4.5.4)
+      '@hono/node-server': 2.1.1(hono@4.13.5)
+      '@tangle-network/agent-core': 0.9.6
+      '@tangle-network/agent-interface': 2.6.0
+      '@tangle-network/agent-trace-contract': 1.0.2
+      hono: 4.13.5
+      linear-sum-assignment: 1.0.9
+      re2js: 2.8.6
+      zod: 4.5.4
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+
+  '@tangle-network/agent-integrations@0.53.55(@types/node@24.13.3)':
+    dependencies:
+      '@duckdb/node-api': 1.5.5-r.2
+      amqplib: 2.0.1
+      csv-parse: 7.0.1
+      csv-stringify: 6.8.1
+      hyparquet: 1.27.1
+      hyparquet-writer: 0.16.1
+      ipaddr.js: 2.4.0
+      jose: 6.2.4
+      kafkajs: 2.2.4
+      mongodb: 6.21.0
+      mysql2: 3.23.2(@types/node@24.13.3)
+      pg: 8.22.0
+      read-excel-file: 9.3.5
+      redis: 6.1.0
+      ssh2-sftp-client: 12.1.1
+      write-excel-file: 4.1.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
+      - '@types/node'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - pg-native
+      - snappy
+      - socks
+
+  '@tangle-network/agent-interface@2.3.0':
+    dependencies:
+      '@noble/hashes': 2.4.0
+      spdx-expression-parse: 5.0.0
+      zod: 4.5.4
+
+  '@tangle-network/agent-interface@2.6.0':
+    dependencies:
+      '@noble/hashes': 2.4.0
+      spdx-expression-parse: 5.0.0
+      zod: 4.5.4
+
+  '@tangle-network/agent-knowledge@13.0.1(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-interface@2.3.0)':
+    dependencies:
+      '@tangle-network/agent-eval': 0.173.3
+      '@tangle-network/agent-interface': 2.3.0
+      '@types/proper-lockfile': 4.1.4
+      proper-lockfile: 4.1.2
+      zod: 4.5.4
+
+  '@tangle-network/agent-profile-materialize@0.19.2(@tangle-network/agent-interface@2.3.0)':
+    dependencies:
+      '@tangle-network/agent-interface': 2.3.0
+
+  '@tangle-network/agent-runtime@0.192.2(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-interface@2.3.0)(@tangle-network/sandbox@0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4)))':
+    dependencies:
+      '@tangle-network/agent-core': 0.9.6
+      '@tangle-network/agent-eval': 0.173.3
+      '@tangle-network/agent-interface': 2.3.0
+      '@tangle-network/agent-knowledge': 13.0.1(@tangle-network/agent-eval@0.173.3)(@tangle-network/agent-interface@2.3.0)
+      '@tangle-network/agent-profile-materialize': 0.19.2(@tangle-network/agent-interface@2.3.0)
+      '@tangle-network/agent-trace-contract': 1.0.2
+      '@tangle-network/sandbox': 0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4))
+      tar-stream: 3.2.1
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  '@tangle-network/agent-trace-contract@1.0.2': {}
+
+  '@tangle-network/sandbox@0.37.0(viem@2.56.2(typescript@5.9.3)(zod@4.5.4))':
+    dependencies:
+      '@tangle-network/agent-core': 0.9.6
+      '@tangle-network/agent-interface': 2.3.0
+      zod: 4.5.4
+    optionalDependencies:
+      viem: 2.56.2(typescript@5.9.3)(zod@4.5.4)
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -1383,6 +2260,18 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.5
+
+  '@types/retry@0.12.5': {}
+
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@11.0.5':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
   '@vitest/coverage-v8@4.1.11(vitest@4.1.11)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -1395,7 +2284,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -1406,13 +2295,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.11(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1))':
+  '@vitest/mocker@4.1.11(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)
+      vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -1438,13 +2327,20 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  abitype@1.2.3(typescript@5.9.3):
+  abitype@1.2.3(typescript@5.9.3)(zod@4.5.4):
     optionalDependencies:
       typescript: 5.9.3
+      zod: 4.5.4
 
   acorn@8.16.0: {}
 
+  amqplib@2.0.1: {}
+
   any-promise@1.3.0: {}
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
 
   assertion-error@2.0.1: {}
 
@@ -1453,6 +2349,52 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  aws-ssl-profiles@1.1.2: {}
+
+  b4a@1.8.1: {}
+
+  bare-events@2.9.2: {}
+
+  bare-fs@4.8.1:
+    dependencies:
+      bare-events: 2.9.2
+      bare-path: 3.1.2
+      bare-stream: 2.13.4(bare-events@2.9.2)
+      bare-url: 2.5.4
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.2: {}
+
+  bare-stream@2.13.4(bare-events@2.9.2):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.1
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.5.4:
+    dependencies:
+      bare-path: 3.1.2
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  binary-search@1.3.6: {}
+
+  bson@6.10.4: {}
+
+  buffer-from@1.1.2: {}
+
+  buildcheck@0.0.7:
+    optional: true
 
   bundle-require@5.1.0(esbuild@0.28.1):
     dependencies:
@@ -1463,11 +2405,22 @@ snapshots:
 
   chai@6.2.2: {}
 
+  cheminfo-types@1.15.0: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
 
+  cluster-key-slot@1.1.2: {}
+
   commander@4.1.1: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
 
   confbox@0.1.8: {}
 
@@ -1475,9 +2428,21 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.28.0
+    optional: true
+
+  csv-parse@7.0.1: {}
+
+  csv-stringify@6.8.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  denque@2.1.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -1518,7 +2483,15 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   expect-type@1.3.0: {}
+
+  fast-fifo@1.3.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -1527,6 +2500,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
       picomatch: 4.0.7
+
+  fflate@0.8.3: {}
+
+  fft.js@4.0.4: {}
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -1537,11 +2514,37 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
+  graceful-fs@4.2.11: {}
+
   has-flag@4.0.0: {}
 
   hono@4.13.5: {}
 
   html-escaper@2.0.2: {}
+
+  hyparquet-writer@0.16.1:
+    dependencies:
+      hyparquet: 1.26.1
+
+  hyparquet@1.26.1: {}
+
+  hyparquet@1.27.1: {}
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@2.4.0: {}
+
+  is-any-array@3.0.0: {}
+
+  is-property@1.0.2: {}
 
   isows@1.0.7(ws@8.21.0):
     dependencies:
@@ -1560,9 +2563,13 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  jose@6.2.4: {}
+
   joycon@3.1.1: {}
 
   js-tokens@10.0.0: {}
+
+  kafkajs@2.2.4: {}
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -1615,9 +2622,19 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
+  linear-sum-assignment@1.0.9:
+    dependencies:
+      cheminfo-types: 1.15.0
+      ml-matrix: 6.15.0
+      ml-spectra-processing: 14.34.0
+
   lines-and-columns@1.2.4: {}
 
   load-tsconfig@0.2.5: {}
+
+  long@5.3.2: {}
+
+  lru.min@1.1.5: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -1633,6 +2650,38 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  memory-pager@1.5.0: {}
+
+  ml-array-max@2.0.0:
+    dependencies:
+      is-any-array: 3.0.0
+
+  ml-array-min@2.0.0:
+    dependencies:
+      is-any-array: 3.0.0
+
+  ml-array-rescale@2.0.0:
+    dependencies:
+      is-any-array: 3.0.0
+      ml-array-max: 2.0.0
+      ml-array-min: 2.0.0
+
+  ml-matrix@6.15.0:
+    dependencies:
+      is-any-array: 3.0.0
+      ml-array-rescale: 2.0.0
+
+  ml-spectra-processing@14.34.0:
+    dependencies:
+      binary-search: 1.3.6
+      cheminfo-types: 1.15.0
+      fft.js: 4.0.4
+      is-any-array: 3.0.0
+      ml-matrix: 6.15.0
+      ml-xsadd: 3.0.1
+
+  ml-xsadd@3.0.1: {}
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
@@ -1640,7 +2689,30 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  mongodb-connection-string-url@3.0.2:
+    dependencies:
+      '@types/whatwg-url': 11.0.5
+      whatwg-url: 14.2.0
+
+  mongodb@6.21.0:
+    dependencies:
+      '@mongodb-js/saslprep': 1.5.2
+      bson: 6.10.4
+      mongodb-connection-string-url: 3.0.2
+
   ms@2.1.3: {}
+
+  mysql2@3.23.2(@types/node@24.13.3):
+    dependencies:
+      '@types/node': 24.13.3
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.3
+      long: 5.3.2
+      lru.min: 1.1.5
+      named-placeholders: 1.1.6
+      sql-escaper: 1.5.1
 
   mz@2.7.0:
     dependencies:
@@ -1648,13 +2720,26 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.5
+
+  nan@2.28.0:
+    optional: true
+
   nanoid@3.3.18: {}
+
+  node-int64@0.4.0: {}
 
   object-assign@4.1.1: {}
 
   obug@2.1.1: {}
 
-  ox@0.14.44(typescript@5.9.3):
+  openapi3-ts@4.6.1:
+    dependencies:
+      yaml: 2.9.0
+
+  ox@0.14.44(typescript@5.9.3)(zod@4.5.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -1662,7 +2747,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.5.4)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -1670,6 +2755,41 @@ snapshots:
       - zod
 
   pathe@2.0.3: {}
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.16.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -1685,11 +2805,12 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.23):
+  postcss-load-config@6.0.1(postcss@8.5.23)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.23
+      yaml: 2.9.0
 
   postcss@8.5.23:
     dependencies:
@@ -1697,9 +2818,55 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  punycode@2.3.1: {}
+
+  re2js@2.8.6: {}
+
+  read-excel-file@9.3.5:
+    dependencies:
+      fflate: 0.8.3
+      saxen: 11.1.1
+      unzipper-esm: 0.13.3
+      worker-f: 0.1.20
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@4.1.2: {}
 
+  redis@6.1.0:
+    dependencies:
+      '@redis/bloom': 6.1.0(@redis/client@6.1.0)
+      '@redis/client': 6.1.0
+      '@redis/json': 6.1.0(@redis/client@6.1.0)
+      '@redis/search': 6.1.0(@redis/client@6.1.0)
+      '@redis/time-series': 6.1.0(@redis/client@6.1.0)
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
+
   resolve-from@5.0.0: {}
+
+  retry@0.12.0: {}
 
   rolldown@1.0.3:
     dependencies:
@@ -1753,17 +2920,68 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxen@11.1.1: {}
+
   semver@7.7.4: {}
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
 
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@5.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
+  split2@4.2.0: {}
+
+  sql-escaper@1.5.1: {}
+
+  ssh2-sftp-client@12.1.1:
+    dependencies:
+      concat-stream: 2.0.0
+      ssh2: 1.17.0
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.28.0
+
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
+
+  streamx@2.28.1:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   sucrase@3.35.1:
     dependencies:
@@ -1778,6 +2996,30 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  tar-stream@3.2.1:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   thenify-all@1.6.0:
     dependencies:
@@ -1805,6 +3047,10 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
@@ -1812,7 +3058,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.23)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.23)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -1823,7 +3069,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.23)
+      postcss-load-config: 6.0.1(postcss@8.5.23)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.60.2
       source-map: 0.7.6
@@ -1840,21 +3086,32 @@ snapshots:
       - tsx
       - yaml
 
+  tweetnacl@0.14.5: {}
+
+  typedarray@0.0.6: {}
+
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
 
   undici-types@7.18.2: {}
 
-  viem@2.56.2(typescript@5.9.3):
+  unzipper-esm@0.13.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      node-int64: 0.4.0
+
+  util-deprecate@1.0.2: {}
+
+  viem@2.56.2(typescript@5.9.3)(zod@4.5.4):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.5.4)
       isows: 1.0.7(ws@8.21.0)
-      ox: 0.14.44(typescript@5.9.3)
+      ox: 0.14.44(typescript@5.9.3)(zod@4.5.4)
       ws: 8.21.0
     optionalDependencies:
       typescript: 5.9.3
@@ -1863,7 +3120,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1):
+  vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.7
@@ -1874,11 +3131,12 @@ snapshots:
       '@types/node': 24.13.3
       esbuild: 0.28.1
       fsevents: 2.3.3
+      yaml: 2.9.0
 
-  vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)):
+  vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1))
+      '@vitest/mocker': 4.1.11(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -1895,7 +3153,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)
+      vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
@@ -1903,9 +3161,30 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  webidl-conversions@7.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  worker-f@0.1.20: {}
+
+  write-excel-file@4.1.1:
+    dependencies:
+      fflate: 0.8.3
+
   ws@8.21.0: {}
+
+  xtend@4.0.2: {}
+
+  yaml@2.9.0: {}
+
+  zod@4.4.3: {}
+
+  zod@4.5.4: {}

--- a/src/a2a/message-send-execution.ts
+++ b/src/a2a/message-send-execution.ts
@@ -1,3 +1,4 @@
+import { SandboxStreamError } from '../sandbox-stream-error'
 import type { Context } from 'hono'
 import {
   type AuthorizedRequest,
@@ -122,6 +123,7 @@ export async function executeMessageSend(
       deps.payment,
       err instanceof Error ? err.message : String(err),
       workObserved || usage !== undefined,
+      err instanceof SandboxStreamError ? usage : undefined,
     )
     const currentTask = await deps.taskStore.get(task.id) ?? releasedTask
     const failed = shouldPreserveTask(currentTask)

--- a/src/a2a/message-stream-execution.ts
+++ b/src/a2a/message-stream-execution.ts
@@ -1,3 +1,4 @@
+import { SandboxStreamError } from '../dispatch-sandbox'
 import type { Context } from 'hono'
 import {
   type AuthorizedRequest,
@@ -322,6 +323,7 @@ export async function executeMessageStream(
             lifecycle.payment,
             err instanceof Error ? err.message : String(err),
             workObserved || usage !== undefined,
+            err instanceof SandboxStreamError ? usage : undefined,
           )
           if (finalizationLeaseId) {
             const retained = await retainFinalizationForRecovery(

--- a/src/a2a/payment-recovery.ts
+++ b/src/a2a/payment-recovery.ts
@@ -48,6 +48,7 @@ export interface PaymentRecoveryDependencies {
     authz: AuthorizedRequest,
     reason: string,
     workObserved: boolean,
+    usage?: SandboxUsageReceipt,
   ) => Promise<void>
   recoverDurablePayment: (
     recoveryId: string,
@@ -128,6 +129,7 @@ export async function releaseTaskPayment(
   deps: PaymentRecoveryDependencies,
   reason: string,
   workObserved: boolean,
+  usage?: SandboxUsageReceipt,
 ): Promise<Task> {
   if (
     !workObserved &&
@@ -166,7 +168,7 @@ export async function releaseTaskPayment(
   }
 
   try {
-    await deps.releasePaymentAfterFailure(authz, reason, workObserved)
+    await deps.releasePaymentAfterFailure(authz, reason, workObserved, usage)
   } catch (releaseError) {
     console.error(
       `[a2a] payment release failed for ${authz.requestId}:`,
@@ -174,9 +176,7 @@ export async function releaseTaskPayment(
     )
   }
   const current = await deps.taskStore.get(task.id) ?? task
-  return workObserved
-    ? current
-    : clearReconciledPaymentRecoveryMarker(current, deps)
+  return clearReconciledPaymentRecoveryMarker(current, deps)
 }
 
 async function beginPaymentReleaseRecovery(

--- a/src/a2a/task-lifecycle.ts
+++ b/src/a2a/task-lifecycle.ts
@@ -30,8 +30,8 @@ export function createTaskLifecycle(deps: TaskLifecycleDependencies): TaskLifecy
     paymentOperations: deps.config.x402.paymentOperations,
     paymentRecovery: deps.config.paymentRecovery,
     releasePayment: (authz, reason) => releasePayment(authz, deps.config, reason),
-    releasePaymentAfterFailure: (authz, reason, workObserved) =>
-      releasePaymentAfterFailure(authz, deps.config, reason, workObserved),
+    releasePaymentAfterFailure: (authz, reason, workObserved, usage) =>
+      releasePaymentAfterFailure(authz, deps.config, reason, workObserved, usage),
     recoverDurablePayment: (recoveryId, options) =>
       recoverDurablePayment(recoveryId, deps.config, options),
     deliverPush: deps.deliverPush,

--- a/src/dispatch-payment.ts
+++ b/src/dispatch-payment.ts
@@ -1,3 +1,4 @@
+import { settleAndRecord } from './dispatch-settlement'
 import { apiKeyReservationQuote, assertApiKeyRequestClaim } from './api-key-budget'
 import {
   assertMppChargeOperation,
@@ -378,15 +379,27 @@ async function updateExecutionLease(
 }
 
 /**
- * Release only when no sandbox work was observed. Once output or a receipt
- * exists, retain the owner for settlement or background recovery.
+ * Settle enforced failed-run usage; release only before sandbox work.
+ * Retain unresolved ownership and measured receipts for background recovery.
  */
 export async function releasePaymentAfterFailure(
   authz: AuthorizedRequest,
   config: GatewayConfig,
   reason: string,
   workObserved: boolean,
+  usage?: import('./types').SandboxUsageReceipt,
 ): Promise<void> {
+  if (usage?.budgetEnforced === true) {
+    try {
+      await settleAndRecord(authz.agent, authz, usage, config, config.observer)
+      return
+    } catch (error) {
+      // Settlement owns durable receipt capture before external effects. Keep
+      // its measured recovery record if acknowledgement or attribution failed.
+      console.error(`[agent-gateway] failed-run receipt settlement pending for ${authz.requestId}:`,
+        error instanceof Error ? error.message : String(error))
+    }
+  }
   if (workObserved) {
     const recovery = config.paymentRecovery
     if (recovery && authz.paymentRecoveryId) {

--- a/src/dispatch-sandbox.ts
+++ b/src/dispatch-sandbox.ts
@@ -1,3 +1,5 @@
+import { SandboxStreamError } from './sandbox-stream-error'
+export { SandboxStreamError } from './sandbox-stream-error'
 import { prepareApiKeyPrompt } from './api-key-budget'
 import { redactSystemPromptFromOutput } from './filter'
 import type { A2ADispatchEvent, AuthorizedRequest } from './dispatch-types'
@@ -26,29 +28,6 @@ export function buildGatewaySandboxContext(
     messages: authz.messages ?? [],
     ...(authz.apiKeyReservedCents !== undefined ? { apiKeyReservation: { cents: authz.apiKeyReservedCents, executionBudget: authz.executionBudget } } : {}),
     ...(authz.threadId !== undefined ? { threadId: authz.threadId } : {}),
-  }
-}
-
-/** Terminal failure reported by the sandbox event protocol. */
-export class SandboxStreamError extends Error {
-  readonly eventType: string
-  readonly code?: string
-  readonly details?: Record<string, unknown>
-
-  constructor(event: SandboxStreamEvent) {
-    const rawMessage = event.data?.message
-    const message = typeof rawMessage === 'string' && rawMessage.trim().length > 0
-      ? rawMessage.trim()
-      : 'Sandbox stream failed'
-    super(message)
-    this.name = 'SandboxStreamError'
-    this.eventType = event.type ?? 'unknown'
-    if (typeof event.data?.code === 'string' && event.data.code.length > 0) {
-      this.code = event.data.code
-    }
-    if (event.data?.details && typeof event.data.details === 'object' && !Array.isArray(event.data.details)) {
-      this.details = event.data.details
-    }
   }
 }
 
@@ -177,10 +156,20 @@ export async function* dispatchSandboxStreamRich(
       }
       if (next.done) break
       const event = next.value
+      if (event.data?.usage) usageParts = mergeUsage(usageParts, event.data.usage)
       if (event.type === 'error' || event.type === 'session.run.failed') {
+        // A failed run can still have a final, provider-enforced charge.
+        // The producer must send that receipt before its terminal error.
+        let usage: SandboxUsageReceipt
+        try {
+          usage = finalizeUsage(withObservedUsage(usageParts, observedReasoningTokens,
+            observedToolTokens, observedToolCalls), executionBudget)
+        } catch (cause) {
+          throw new SandboxStreamError(event, { cause })
+        }
+        yield { kind: 'usage', usage }
         throw new SandboxStreamError(event)
       }
-      if (event.data?.usage) usageParts = mergeUsage(usageParts, event.data.usage)
       if (event.data?.reasoning?.tokens !== undefined) {
         observedReasoningTokens += nonNegativeSafeInteger(event.data.reasoning.tokens, 'reasoning tokens')
         yield { kind: 'activity' }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,4 @@
+import { SandboxStreamError } from './dispatch-sandbox'
 import { ApiKeyBudgetUnsupportedError } from './api-key-budget'
 import { Hono } from 'hono'
 
@@ -605,6 +606,7 @@ async function releaseCompletionAfterFailure(
       config,
       error instanceof Error ? error.message : String(error),
       workObserved || usage !== undefined,
+      error instanceof SandboxStreamError ? usage : undefined,
     )
   } catch (releaseError) {
     console.error(

--- a/src/sandbox-stream-error.ts
+++ b/src/sandbox-stream-error.ts
@@ -1,0 +1,25 @@
+import type { SandboxStreamEvent } from './types'
+
+/** Terminal failure reported by the sandbox event protocol. */
+export class SandboxStreamError extends Error {
+  readonly eventType: string
+  readonly code?: string
+  readonly details?: Record<string, unknown>
+
+  constructor(event: SandboxStreamEvent, options?: ErrorOptions) {
+    const rawMessage = event.data?.message
+    const message = typeof rawMessage === 'string' && rawMessage.trim().length > 0
+      ? rawMessage.trim()
+      : 'Sandbox stream failed'
+    super(message, options)
+    this.name = 'SandboxStreamError'
+    this.eventType = event.type ?? 'unknown'
+    if (typeof event.data?.code === 'string' && event.data.code.length > 0) {
+      this.code = event.data.code
+    }
+    if (event.data?.details && typeof event.data.details === 'object' && !Array.isArray(event.data.details)) {
+      this.details = event.data.details
+    }
+  }
+}
+

--- a/tests/api-key-reservations.test.ts
+++ b/tests/api-key-reservations.test.ts
@@ -22,14 +22,14 @@ async function fixture(cap: number | null = 1) {
 }
 
 
-function gateway(store: SqlApiKeyStore, box: SandboxBox) {
+function gateway(store: SqlApiKeyStore, box: SandboxBox, maxProviderCostUsd = 0.01) {
   return createAgentGateway({
       resolveAgent: async () => ({ id: 'agent', ownerId: 'owner', slug: 'agent', enabled: true, pricePerTokenUsd: 0, platformFeePercent: 0, sandboxEndpoint: null, remoteSandboxId: null, remoteBearerToken: null }),
       authorizeConsumer: async () => ({ allow: true }),
       verifyApiKey: header => verifyApiKeyFromStore(header, store),
       claimApiKeyRequest: createApiKeyRequestClaim(store), apiKeyReservationLifecycle: store.reservations,
       settlePayment: createApiKeyUsageSettlement(store), recordUsage: async () => {}, getSandbox: async () => box,
-      executionBudget: { maxProviderCostUsd: 0.01 }, a2a: false,
+      executionBudget: { maxProviderCostUsd }, a2a: false,
     })
 }
 
@@ -38,6 +38,41 @@ function request(app: ReturnType<typeof createAgentGateway>, token: string) {
 }
 
 describe('API key spending reservations', () => {
+  it.each([true, false])('settles a failed run from its enforced receipt (stream=%s)', async (stream) => {
+    const { db, store, token } = await fixture(20)
+    const app = gateway(store, {
+      async *streamPrompt() { throw new Error('Unbounded execution is forbidden') },
+      async prepareBudgetedPrompt() { return { status: 'prepared', start: async function* () {
+        yield { type: 'sandbox.usage', data: { usage: { inputTokens: 0, outputTokens: 1, toolCallCount: 0, providerCostUsd: 0.02, budgetEnforced: true } } }
+        yield { type: 'error', data: { message: 'Tool failed after paid inference' } }
+      } } },
+    }, 0.1)
+    try {
+      const response = await app.request('/agent/chat/completions', { method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ messages: [{ role: 'user', content: 'x' }], stream }) })
+      expect(await response.text()).toContain('Tool failed after paid inference')
+      expect((await store.list('owner'))[0].spentCents).toBe(2)
+      expect(db.prepare('SELECT cost_cents FROM agent_api_key_usage').get()).toMatchObject({ cost_cents: 2 })
+      expect((await store.claimRequest((await store.list('owner'))[0].id, 'remaining', undefined, 18)).allowed).toBe(true)
+    } finally { db.close() }
+  })
+
+  it.each([undefined, false])('retains failed-run ownership without enforced usage (%s)', async (budgetEnforced) => {
+    const { db, store, token } = await fixture()
+    const app = gateway(store, {
+      async *streamPrompt() { throw new Error('Unbounded execution is forbidden') },
+      async prepareBudgetedPrompt() { return { status: 'prepared', start: async function* () {
+        if (budgetEnforced !== undefined) yield { type: 'sandbox.usage', data: { usage: { inputTokens: 0, outputTokens: 1, toolCallCount: 0, providerCostUsd: 0.002, budgetEnforced } } }
+        yield { type: 'error', data: { message: 'Tool failed after paid inference' } }
+      } } },
+    })
+    try {
+      expect(await (await request(app, token)).text()).toContain('Tool failed after paid inference')
+      expect((await store.list('owner'))[0].spentCents).toBe(0)
+      expect(db.prepare('SELECT state FROM agent_api_key_reservation').get()).toMatchObject({ state: 'executing' })
+      expect((await request(app, token)).status).toBe(429)
+    } finally { db.close() }
+  })
+
   it.each(['preparation', 'execution-start'])('removes abort forwarding when %s fails', async (failure) => {
     const controller = new AbortController()
     const added = vi.spyOn(controller.signal, 'addEventListener')

--- a/tests/failed-execution-receipts.test.ts
+++ b/tests/failed-execution-receipts.test.ts
@@ -1,0 +1,108 @@
+import { InMemoryTaskStore } from '../src/a2a/task-store'
+import { ServerAssignedTaskStore } from './server-assigned-task-store'
+import { describe, expect, it } from 'vitest'
+import { createAgentGateway } from '../src/middleware'
+import { MemoryPaymentOperations } from '../src/payment-operations'
+import { MemoryPaymentRecoveryStore } from '../src/payment-recovery'
+import { recoverPayment } from '../src/payment-recovery-worker'
+import type { GatewayConfig, GatewayUsageEvent, SandboxExecutionBudget, SandboxUsageReceipt } from '../src/types'
+
+const agent = { id: 'inclusive', ownerId: 'owner', slug: 'inclusive', enabled: true,
+  pricePerTokenUsd: 0.001, platformFeePercent: 0, sandboxEndpoint: null,
+  remoteSandboxId: null, remoteBearerToken: null }
+const commitment = `0x${'ab'.repeat(32)}`
+const totals: SandboxUsageReceipt = { inputTokens: 10, outputTokens: 6,
+  reasoningTokens: 2, toolTokens: 4, toolCallCount: 1, providerCostUsd: 0.001, budgetEnforced: true }
+
+function fixture(details?: GatewayConfig['executionBudget']) {
+  let received: SandboxExecutionBudget | undefined
+  const settlements: bigint[] = []
+  const usageEvents: GatewayUsageEvent[] = []
+  const recovery = new MemoryPaymentRecoveryStore()
+  const operations = new MemoryPaymentOperations({ onSettle: async (_op, input) => { settlements.push(input.amount) }, onReclaim: async () => {} })
+  const config: GatewayConfig = {
+    resolveAgent: async () => agent, authorizeConsumer: async () => ({ allow: true }),
+    getSandbox: async () => ({ async *streamPrompt(_message, options) {
+      received = options?.executionBudget
+      yield { type: 'usage', data: { usage: totals } }
+    } }), recordUsage: async event => { usageEvents.push(event) },
+    maxOutputTokens: 20, defaultOutputTokens: 20, unauthenticatedInputTokenBound: 100,
+    executionBudget: details,
+    x402: { operatorAddress: '0x1', chainId: 1, demoMode: true,
+      paymentProtocolVersion: 2, paymentOperations: operations },
+    paymentRecovery: { store: recovery, retryDelayMs: 1 },
+  }
+  return { config, recovery, operations, settlements, usageEvents, received: () => received }
+}
+
+async function request(config: GatewayConfig, stream = false) {
+  const response = await createAgentGateway(config).request('/inclusive/chat/completions', {
+    method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': JSON.stringify({
+      commitment, signature: '0xsig', operator: '0x1', amount: '1000000', nonce: '42',
+      expiry: String(Math.floor(Date.now() / 1000) + 600),
+    }) }, body: JSON.stringify({ stream, messages: [{ role: 'user', content: 'test' }] }),
+  })
+  return { status: response.status, text: await response.text() }
+}
+
+describe('failed execution receipts', () => {
+  it.each([false, true])('settles measured usage while returning an error (stream=%s)', async stream => {
+    const f = fixture()
+    f.config.getSandbox = async () => ({ async *streamPrompt() {
+      yield { type: 'usage', data: { usage: totals } }
+      yield { type: 'error', data: { message: 'Tool failed after paid inference' } }
+    } })
+    const response = await request(f.config, stream)
+    expect(response.text).toContain('Tool failed after paid inference')
+    if (!stream) expect(response.status).toBe(500)
+    expect(f.settlements).toEqual([16000n])
+    expect(f.usageEvents).toHaveLength(1)
+    const record = await f.recovery.get(`x402:${commitment}:42`)
+    expect(record?.state).toBe('reconciled')
+    expect(record?.usage).toEqual(totals)
+  })
+
+  it('recovers a lost settlement acknowledgement from the failed run receipt exactly once', async () => {
+    const f = fixture()
+    const amounts: bigint[] = []
+    const operations = new MemoryPaymentOperations({ onSettle: async (_op, input) => {
+      amounts.push(input.amount)
+      throw new Error('settlement acknowledgement lost')
+    }, onReclaim: async () => {} })
+    f.config.x402.paymentOperations = operations
+    f.config.getSandbox = async () => ({ async *streamPrompt() {
+      yield { type: 'usage', data: { usage: totals } }
+      yield { type: 'session.run.failed', data: { message: 'Paid tool failure' } }
+    } })
+    expect((await request(f.config)).status).toBe(500)
+    const id = `x402:${commitment}:42`
+    expect((await f.recovery.get(id))?.usage).toEqual(totals)
+    expect((await recoverPayment(id, f.config, { force: true }))?.state).toBe('reconciled')
+    await recoverPayment(id, f.config, { force: true })
+    expect(amounts).toEqual([16000n])
+    expect(operations.get(id)?.settledAmount).toBe(16000n)
+    expect(f.usageEvents).toHaveLength(1)
+  })
+
+  it.each(['message/send', 'message/stream'])('keeps an A2A task failed after reconciling its measured payment (%s)', async method => {
+    const f = fixture()
+    const tasks = new ServerAssignedTaskStore(new InMemoryTaskStore(), 'failed-paid-task')
+    f.config.a2a = { taskStore: tasks, authorizeTaskAccess: async () => true }
+    f.config.getSandbox = async () => ({ async *streamPrompt() {
+      yield { type: 'usage', data: { usage: totals } }
+      yield { type: 'error', data: { message: 'Paid tool failure' } }
+    } })
+    const response = await createAgentGateway(f.config).request('/inclusive', {
+      method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': JSON.stringify({
+        commitment, signature: '0xsig', operator: '0x1', amount: '1000000', nonce: '42',
+        expiry: String(Math.floor(Date.now() / 1000) + 600),
+      }) }, body: JSON.stringify({ jsonrpc: '2.0', id: 'failed', method, params: {
+        message: { kind: 'message', role: 'user', messageId: 'one', parts: [{ kind: 'text', text: 'test' }] },
+      } }),
+    })
+    expect(await response.text()).toContain(method === 'message/send' ? 'Paid tool failure' : '"state":"failed"')
+    expect((await tasks.get('failed-paid-task'))?.status.state).toBe('failed')
+    expect(f.settlements).toEqual([16000n])
+    expect((await f.recovery.get(`x402:${commitment}:42`))?.state).toBe('reconciled')
+  })
+})

--- a/tests/protected-runtime-composition.test.ts
+++ b/tests/protected-runtime-composition.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createProtectedRuntimeChatProducer, createChatTurnRoutes, streamChatRouteAsSandboxEvents, type ProtectedRuntimeChatOptions, type ChatTurnMessageStore } from '@tangle-network/agent-app/chat-routes'
+import { createMemoryTurnEventStore } from '@tangle-network/agent-app/stream'
+import { createAgentGateway } from '../src/middleware'
+import { MemoryPaymentOperations } from '../src/payment-operations'
+import { MemoryPaymentRecoveryStore } from '../src/payment-recovery'
+
+type AgentCandidateModelPort = ProtectedRuntimeChatOptions['grant']['port']
+const digest = 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const
+const model = 'anthropic/claude-haiku-4-5-20251001'
+
+function fixture() {
+  const resolved = { requested: model, model, snapshot: model, provider: 'anthropic', reasoningEffort: 'none' as const }
+  const settle = vi.fn<AgentCandidateModelPort['settleGrant']>(async input => ({
+    preparationId: input.preparationId, grantDigest: digest, closed: true, usageWithinLimits: true,
+    calls: [{ callId: 'call-1', generationId: 'generation-1', traceSpanId: 'generation-1',
+      model, status: 'succeeded', startedAtMs: 1, endedAtMs: 2,
+      inputTokens: 3, accountedInputTokens: 3, outputTokens: 2, cachedInputTokens: 0,
+      reasoningTokens: 0, costUsdNanos: 100_000, costProvenance: 'observed' }],
+  }))
+  const port: AgentCandidateModelPort = {
+    resolve: async () => resolved,
+    reserveGrant: async input => ({ preparationId: input.preparationId, digest,
+      expiresAtMs: input.expiresAtMs, enforcedLimits: input.limits,
+      network: { mode: 'gateway-only', domains: ['candidate-router.tangle.tools'] } }),
+    activateGrant: async () => ({ env: { OPENAI_API_KEY: 'scoped-fixture-token',
+      OPENAI_BASE_URL: 'https://candidate-router.tangle.tools/v1' } }),
+    settleGrant: settle,
+  }
+  const options: ProtectedRuntimeChatOptions = {
+    profile: { name: 'protected-test', harness: 'cli-base', prompt: { systemPrompt: 'Use the available tools.' },
+      model: { provider: 'tangle-router', default: model, reasoningEffort: 'none', maxVisibleOutputTokens: 100 } },
+    prompt: 'Read the current brief and save a useful finding.', tools: [], maxToolCalls: 2,
+    grant: { port, resolve: { requested: model, harness: 'cli-base', reasoningEffort: 'none' },
+      reserve: { executionId: 'execution-1', preparationId: 'preparation-1', bundleDigest: digest,
+        expiresAtMs: Date.now() + 30_000, attempt: { number: 1, maxAttempts: 1, retryPolicy: 'none' },
+        limits: { maxModelCalls: 3, maxInputTokens: 1000, maxOutputTokens: 100, maxCostUsd: 1 } },
+      deadlineAtMs: Date.now() + 20_000 },
+  }
+  return { options, settle }
+}
+
+function response(message: Record<string, unknown>) {
+  return Response.json({ id: 'completion-1', object: 'chat.completion', model,
+    choices: [{ index: 0, message: { role: 'assistant', ...message }, finish_reason: message.tool_calls ? 'tool_calls' : 'stop' }],
+    usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 }, cost: 0.0001 })
+}
+
+
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+describe('protected Runtime failed-run gateway composition', () => {
+  it('settles a paid call after an authorized tool fails through the persisted chat route', async () => {
+    const { options, settle } = fixture()
+    const abort = new AbortController()
+    options.signal = abort.signal
+    const effect = vi.fn(async () => {
+      const failure = new Error('Synthetic tool database unavailable')
+      abort.abort(failure)
+      throw failure
+    })
+    options.tools = [{ name: 'save', description: 'Save a finding.', inputSchema: { type: 'object' }, run: effect }]
+    options.profile.tools = { save: true }
+    const inference = vi.fn(async () => response({ content: null, tool_calls: [
+      { id: 'first', type: 'function', function: { name: 'save', arguments: '{}' } },
+    ] }))
+    vi.stubGlobal('fetch', inference)
+    const rows: Array<Awaited<ReturnType<ChatTurnMessageStore['appendMessage']>>> = []
+    const pending: Promise<unknown>[] = []
+    const store: ChatTurnMessageStore = {
+      listMessages: async threadId => rows.filter(row => row.threadId === threadId),
+      appendMessage: async input => { const row = { id: `message-${rows.length}`, ...input }; rows.push(row); return row },
+      updateMessage: async (id, patch) => { const row = rows.find(row => row.id === id); if (row) Object.assign(row, patch); return row ?? null },
+      deleteMessage: async () => null,
+    }
+    const routes = createChatTurnRoutes({ projectId: 'synthetic-composed',
+      authorize: async () => ({ ok: true, tenantId: 'publication', userId: 'payer', context: undefined }),
+      store, turnStore: createMemoryTurnEventStore(), log: () => {},
+      produce: () => createProtectedRuntimeChatProducer(options),
+    })
+    const amounts: bigint[] = []
+    const recorded: unknown[] = []
+    const recovery = new MemoryPaymentRecoveryStore()
+    const operations = new MemoryPaymentOperations({ onSettle: async (_op, input) => { amounts.push(input.amount) }, onReclaim: async () => {} })
+    const app = createAgentGateway({
+      resolveAgent: async () => ({ id: 'composed', ownerId: 'owner', slug: 'composed', enabled: true,
+        pricePerTokenUsd: 0.001, platformFeePercent: 0, sandboxEndpoint: null, remoteSandboxId: null, remoteBearerToken: null }),
+      authorizeConsumer: async () => ({ allow: true }), recordUsage: async event => { recorded.push(event) },
+      maxOutputTokens: 100, defaultOutputTokens: 100, unauthenticatedInputTokenBound: 1000,
+      getSandbox: async () => ({ streamPrompt: () => streamChatRouteAsSandboxEvents({
+        routes, request: new Request('https://synthetic.test/api/chat'), payload: { workspaceId: 'publication', threadId: 'payer-thread', content: options.prompt },
+        waitUntil: promise => { pending.push(promise) },
+      }) }),
+      x402: { operatorAddress: '0x1', chainId: 1, demoMode: true, paymentProtocolVersion: 2, paymentOperations: operations },
+      paymentRecovery: { store: recovery, retryDelayMs: 1 }, a2a: false,
+    })
+    const commitment = `0x${'cd'.repeat(32)}`
+    const result = await app.request('/composed/chat/completions', {
+      method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Payment-Signature': JSON.stringify({
+        commitment, signature: '0xsig', operator: '0x1', amount: '10000000', nonce: '47',
+        expiry: String(Math.floor(Date.now() / 1000) + 600),
+      }) }, body: JSON.stringify({ messages: [{ role: 'user', content: options.prompt }], stream: false }),
+    })
+    const body = await result.text()
+    await Promise.all(pending)
+    expect(result.status, body).toBe(500)
+    expect(inference).toHaveBeenCalledOnce()
+    expect(effect).toHaveBeenCalledOnce()
+    expect(settle).toHaveBeenCalledOnce()
+    expect(amounts).toEqual([5000n])
+    expect(recorded).toHaveLength(1)
+    expect(recorded[0]).toMatchObject({ inputTokens: 3, outputTokens: 2, providerCostUsd: 0.0001, toolCallCount: 1 })
+    expect((await recovery.get(`x402:${commitment}:47`))?.state).toBe('reconciled')
+    expect(body).not.toContain('scoped-fixture-token')
+  })
+})


### PR DESCRIPTION
A sandbox error could discard an authoritative receipt emitted after paid inference. Payment cleanup then retained the quote despite having measured usage.

Validate and forward enforced usage before terminal protocol errors, then settle the measured amount while preserving OpenAI errors and failed A2A tasks. Missing or unenforced receipts retain ownership under the existing recovery policy. Settlement acknowledgement failures preserve the durable measured receipt. Ordinary finalization failures keep their existing recovery behavior.

Validation: 498 tests pass on Node 24.18.0 and 22.22.2; typecheck and build pass. New coverage exercises OpenAI JSON/SSE, both A2A methods, real SQLite capped-key reservations, acknowledgement-loss recovery, and published agent-app 0.47.6 with the maintained Runtime producer, persisted chat route, and gateway bridge. Removing the failed-receipt handoff fails the composed regression.

All remote inference and payment effects use synthetic callbacks. The tests establish local accounting and protocol behavior, not external payment transfer or live provider enforcement. Version 0.11.1 contains this correction.
